### PR TITLE
Support full XPath expressions

### DIFF
--- a/src/xml/xml.h
+++ b/src/xml/xml.h
@@ -1,4 +1,6 @@
 
+#pragma once
+
 #include <memory>
 
 struct ParseState {

--- a/src/xml/xpath/xpath_ast.h
+++ b/src/xml/xpath/xpath_ast.h
@@ -93,6 +93,7 @@ enum class XPathNodeType {
 
    // Expressions
    Expression,
+   Filter,
    BinaryOp,
    UnaryOp,
    FunctionCall,

--- a/src/xml/xpath/xpath_axis.cpp
+++ b/src/xml/xpath/xpath_axis.cpp
@@ -1,6 +1,8 @@
 // XPath Axis Evaluation System Implementation
 
 #include <algorithm>
+#include <map>
+#include <unordered_set>
 
 //********************************************************************************************************************
 // AxisEvaluator Implementation
@@ -38,6 +40,10 @@ std::vector<XMLTag *> AxisEvaluator::evaluate_axis(AxisType Axis, XMLTag *Contex
       default:
          return {};
    }
+}
+
+void AxisEvaluator::reset_namespace_nodes() {
+   namespace_node_storage.clear();
 }
 
 AxisType AxisEvaluator::parse_axis_name(std::string_view AxisName) {
@@ -264,8 +270,67 @@ std::vector<XMLTag *> AxisEvaluator::evaluate_attribute_axis(XMLTag *Node) {
 }
 
 std::vector<XMLTag *> AxisEvaluator::evaluate_namespace_axis(XMLTag *Node) {
-   // Namespace nodes are not implemented as separate nodes in Parasol
-   return {};
+   std::vector<XMLTag *> namespaces;
+
+   if (!Node) return namespaces;
+
+   std::map<std::string, std::string, std::less<>> in_scope;
+
+   auto add_namespace = [&](const std::string &Prefix, const std::string &URI) {
+      if (in_scope.find(Prefix) != in_scope.end()) return;
+      in_scope.insert({ Prefix, URI });
+   };
+
+   add_namespace("xml", "http://www.w3.org/XML/1998/namespace");
+
+   std::unordered_set<int> visited_ids;
+   XMLTag *current = Node;
+
+   while (current) {
+      if (visited_ids.insert(current->ID).second) {
+         for (size_t index = 1; index < current->Attribs.size(); ++index) {
+            const auto &attrib = current->Attribs[index];
+
+            if (attrib.Name.rfind("xmlns", 0) != 0) continue;
+
+            std::string prefix;
+            if (attrib.Name.length() IS 5) prefix.clear();
+            else if ((attrib.Name.length() > 6) and (attrib.Name[5] IS ':')) {
+               prefix = attrib.Name.substr(6);
+            }
+            else continue;
+
+            add_namespace(prefix, attrib.Value);
+         }
+      }
+
+      if (!current->ParentID) break;
+      current = find_tag_by_id(current->ParentID);
+   }
+
+   auto emit_namespace = [&](const std::string &Prefix, const std::string &URI) {
+      auto node = std::make_unique<XMLTag>(0);
+      node->Attribs.clear();
+      node->Children.clear();
+      node->Attribs.emplace_back(Prefix, std::string());
+
+      XMLTag content_node(0);
+      content_node.Attribs.clear();
+      content_node.Children.clear();
+      content_node.Attribs.emplace_back(std::string(), URI);
+      node->Children.push_back(content_node);
+
+      node->NamespaceID = xml ? xml->registerNamespace(URI) : 0;
+
+      namespaces.push_back(node.get());
+      namespace_node_storage.push_back(std::move(node));
+   };
+
+   for (const auto &entry : in_scope) {
+      emit_namespace(entry.first, entry.second);
+   }
+
+   return namespaces;
 }
 
 std::vector<XMLTag *> AxisEvaluator::evaluate_self_axis(XMLTag *Node) {
@@ -304,13 +369,85 @@ std::vector<XMLTag *> AxisEvaluator::evaluate_ancestor_or_self_axis(XMLTag *Node
 // Document Order Utilities
 
 void AxisEvaluator::sort_document_order(std::vector<XMLTag *> &Nodes) {
-   std::sort(Nodes.begin(), Nodes.end(), [this](XMLTag *a, XMLTag *b) {
-      return is_before_in_document_order(a, b);
+   if (Nodes.size() < 2) return;
+
+   std::sort(Nodes.begin(), Nodes.end(), [this](XMLTag *Left, XMLTag *Right) {
+      if (Left IS Right) return false;
+      if (!Left) return false;
+      if (!Right) return true;
+      return is_before_in_document_order(Left, Right);
    });
 }
 
+std::vector<XMLTag *> AxisEvaluator::build_ancestor_path(XMLTag *Node)
+{
+   std::vector<XMLTag *> path;
+   XMLTag *current = Node;
+
+   while (current) {
+      path.push_back(current);
+      if (!current->ParentID) break;
+      current = find_tag_by_id(current->ParentID);
+   }
+
+   std::reverse(path.begin(), path.end());
+   return path;
+}
+
 bool AxisEvaluator::is_before_in_document_order(XMLTag *Node1, XMLTag *Node2) {
-   // TODO: Implement proper document order comparison
-   // For now, use ID comparison as a simple heuristic
-   return Node1->ID < Node2->ID;
+   if ((!Node1) or (!Node2) or (Node1 IS Node2)) return false;
+
+   if ((Node1->ID IS 0) or (Node2->ID IS 0)) {
+      if (Node1->ID IS Node2->ID) return Node1 < Node2;
+      return Node1->ID < Node2->ID;
+   }
+
+   auto path1 = build_ancestor_path(Node1);
+   auto path2 = build_ancestor_path(Node2);
+
+   if (path1.empty() or path2.empty()) return Node1 < Node2;
+
+   size_t max_common = std::min(path1.size(), path2.size());
+   size_t index = 0;
+
+   while ((index < max_common) and (path1[index] IS path2[index])) index++;
+
+   if (index IS max_common) {
+      return path1.size() < path2.size();
+   }
+
+   if (index IS 0) {
+      return path1[index]->ID < path2[index]->ID;
+   }
+
+   XMLTag *parent = path1[index - 1];
+   XMLTag *branch1 = path1[index];
+   XMLTag *branch2 = path2[index];
+
+   for (auto &child : parent->Children) {
+      if (&child IS branch1) return true;
+      if (&child IS branch2) return false;
+   }
+
+   return branch1->ID < branch2->ID;
+}
+
+void AxisEvaluator::normalise_node_set(std::vector<XMLTag *> &Nodes)
+{
+   size_t write_index = 0;
+   for (size_t read_index = 0; read_index < Nodes.size(); ++read_index) {
+      if (!Nodes[read_index]) continue;
+      Nodes[write_index++] = Nodes[read_index];
+   }
+
+   Nodes.resize(write_index);
+   if (Nodes.size() < 2) return;
+
+   sort_document_order(Nodes);
+
+   auto new_end = std::unique(Nodes.begin(), Nodes.end(), [](XMLTag *Left, XMLTag *Right) {
+      return Left IS Right;
+   });
+
+   Nodes.erase(new_end, Nodes.end());
 }

--- a/src/xml/xpath/xpath_axis.h
+++ b/src/xml/xpath/xpath_axis.h
@@ -9,6 +9,7 @@
 
 #include "xpath_ast.h"
 #include <parasol/modules/xml.h>
+#include <memory>
 #include <string_view>
 #include <vector>
 
@@ -37,6 +38,7 @@ enum class AxisType {
 class AxisEvaluator {
    private:
    extXML * xml;
+   std::vector<std::unique_ptr<XMLTag>> namespace_node_storage;
 
    // Helper methods for specific axes
    std::vector<XMLTag *> evaluate_child_axis(XMLTag *ContextNode);
@@ -58,6 +60,7 @@ class AxisEvaluator {
    // Document order utilities
    void sort_document_order(std::vector<XMLTag *> &Nodes);
    bool is_before_in_document_order(XMLTag *Node1, XMLTag *Node2);
+   std::vector<XMLTag *> build_ancestor_path(XMLTag *Node);
 
    // Helper methods for tag lookup
    XMLTag * find_tag_by_id(int ID);
@@ -68,6 +71,12 @@ class AxisEvaluator {
 
    // Main evaluation method
    std::vector<XMLTag *> evaluate_axis(AxisType Axis, XMLTag *ContextNode);
+
+   // Evaluation lifecycle helpers
+   void reset_namespace_nodes();
+
+   // Node-set utilities
+   void normalise_node_set(std::vector<XMLTag *> &Nodes);
 
    // Utility methods
    static AxisType parse_axis_name(std::string_view AxisName);

--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -4,7 +4,6 @@
 #include <cstdlib>
 #include <limits>
 #include <optional>
-#include <unordered_set>
 
 namespace {
 
@@ -83,13 +82,15 @@ std::vector<std::string_view> split_union_paths(std::string_view XPath)
 //********************************************************************************************************************
 // Context Management
 
-void SimpleXPathEvaluator::push_context(XMLTag *Node, size_t Position, size_t Size, const XMLAttrib *Attribute) 
+void SimpleXPathEvaluator::push_context(XMLTag *Node, size_t Position, size_t Size, const XMLAttrib *Attribute)
 {
+   auto document = context.document ? context.document : xml;
    context_stack.push_back(context);
    context.context_node = Node;
    context.attribute_node = Attribute;
    context.position = Position;
    context.size = Size;
+   context.document = document;
 }
 
 void SimpleXPathEvaluator::pop_context() 
@@ -99,6 +100,7 @@ void SimpleXPathEvaluator::pop_context()
       context.attribute_node = nullptr;
       context.position = 1;
       context.size = 1;
+      context.document = xml;
       return;
    }
 
@@ -279,6 +281,8 @@ std::vector<SimpleXPathEvaluator::AxisMatch> SimpleXPathEvaluator::dispatch_axis
       }
 
       case AxisType::Namespace:
+         if (attribute_context) break;
+         if (ContextNode) append_nodes(axis_evaluator.evaluate_axis(AxisType::Namespace, ContextNode));
          break;
    }
 
@@ -293,6 +297,8 @@ ERR SimpleXPathEvaluator::find_tag_enhanced(std::string_view XPath, uint32_t Cur
 }
 
 ERR SimpleXPathEvaluator::find_tag_enhanced_internal(std::string_view XPath, uint32_t CurrentPrefix, bool AllowUnionSplit) {
+   axis_evaluator.reset_namespace_nodes();
+
    if (AllowUnionSplit) {
       auto union_paths = split_union_paths(XPath);
       if (union_paths.size() > 1) {
@@ -364,8 +370,25 @@ ERR SimpleXPathEvaluator::evaluate_ast(const XPathNode *Node, uint32_t CurrentPr
       case XPathNodeType::Step:
          return evaluate_step_ast(Node, CurrentPrefix);
 
+      case XPathNodeType::Path:
+         if ((Node->child_count() > 0) and Node->get_child(0) and
+             (Node->get_child(0)->type IS XPathNodeType::LocationPath)) {
+            return evaluate_location_path(Node->get_child(0), CurrentPrefix);
+         }
+         return evaluate_top_level_expression(Node, CurrentPrefix);
+
+      case XPathNodeType::Expression:
+      case XPathNodeType::Filter:
+      case XPathNodeType::BinaryOp:
+      case XPathNodeType::UnaryOp:
+      case XPathNodeType::FunctionCall:
+      case XPathNodeType::Literal:
+      case XPathNodeType::VariableReference:
+      case XPathNodeType::Number:
+      case XPathNodeType::String:
+         return evaluate_top_level_expression(Node, CurrentPrefix);
+
       default:
-         // TODO: Implement other node types as needed for AST_PLAN.md phases
          return ERR::Failed;
    }
 }
@@ -939,17 +962,7 @@ std::string node_set_string_value(const XPathValue &Value, size_t Index)
 
    if (Index >= Value.node_set.size()) return std::string();
 
-   XMLTag *tag = Value.node_set[Index];
-   if (!tag) return std::string();
-
-   if (tag->isContent()) {
-      if (!tag->Attribs.empty() and !tag->Attribs[0].Value.empty()) {
-         return tag->Attribs[0].Value;
-      }
-      return tag->getContent();
-   }
-
-   return tag->getContent();
+   return XPathValue::node_string_value(Value.node_set[Index]);
 }
 
 double node_set_number_value(const XPathValue &Value, size_t Index)
@@ -957,13 +970,28 @@ double node_set_number_value(const XPathValue &Value, size_t Index)
    std::string str = node_set_string_value(Value, Index);
    if (str.empty()) return std::numeric_limits<double>::quiet_NaN();
 
-   char *end_ptr = nullptr;
-   double result = std::strtod(str.c_str(), &end_ptr);
-   if ((end_ptr IS str.c_str()) or (*end_ptr != '\0')) {
-      return std::numeric_limits<double>::quiet_NaN();
+   return XPathValue::string_to_number(str);
+}
+
+enum class RelationalOperator {
+   Less,
+   LessOrEqual,
+   Greater,
+   GreaterOrEqual
+};
+
+bool numeric_compare(double Left, double Right, RelationalOperator Operation)
+{
+   if (std::isnan(Left) or std::isnan(Right)) return false;
+
+   switch (Operation) {
+      case RelationalOperator::Less: return Left < Right;
+      case RelationalOperator::LessOrEqual: return Left <= Right;
+      case RelationalOperator::Greater: return Left > Right;
+      case RelationalOperator::GreaterOrEqual: return Left >= Right;
    }
 
-   return result;
+   return false;
 }
 
 bool compare_xpath_values(const XPathValue &left_value,
@@ -1007,7 +1035,7 @@ bool compare_xpath_values(const XPathValue &left_value,
 
             for (size_t right_index = 0; right_index < right_value.node_set.size(); ++right_index) {
                std::string right_string = node_set_string_value(right_value, right_index);
-               if (pf::iequals(left_string, right_string)) return true;
+               if (left_string.compare(right_string) IS 0) return true;
             }
          }
 
@@ -1021,7 +1049,7 @@ bool compare_xpath_values(const XPathValue &left_value,
 
       for (size_t index = 0; index < node_value.node_set.size(); ++index) {
          std::string node_string = node_set_string_value(node_value, index);
-         if (pf::iequals(node_string, comparison_string)) return true;
+         if (node_string.compare(comparison_string) IS 0) return true;
       }
 
       return false;
@@ -1029,7 +1057,58 @@ bool compare_xpath_values(const XPathValue &left_value,
 
    std::string left_string = left_value.to_string();
    std::string right_string = right_value.to_string();
-   return pf::iequals(left_string, right_string);
+   return left_string.compare(right_string) IS 0;
+}
+
+bool compare_xpath_relational(const XPathValue &left_value,
+                              const XPathValue &right_value,
+                              RelationalOperator Operation)
+{
+   auto left_type = left_value.type;
+   auto right_type = right_value.type;
+
+   if ((left_type IS XPathValueType::NodeSet) or (right_type IS XPathValueType::NodeSet)) {
+      if ((left_type IS XPathValueType::NodeSet) and (right_type IS XPathValueType::NodeSet)) {
+         for (size_t left_index = 0; left_index < left_value.node_set.size(); ++left_index) {
+            double left_number = node_set_number_value(left_value, left_index);
+            if (std::isnan(left_number)) continue;
+
+            for (size_t right_index = 0; right_index < right_value.node_set.size(); ++right_index) {
+               double right_number = node_set_number_value(right_value, right_index);
+               if (std::isnan(right_number)) continue;
+               if (numeric_compare(left_number, right_number, Operation)) return true;
+            }
+         }
+
+         return false;
+      }
+
+      const XPathValue &node_value = (left_type IS XPathValueType::NodeSet) ? left_value : right_value;
+      const XPathValue &other_value = (left_type IS XPathValueType::NodeSet) ? right_value : left_value;
+
+      if (other_value.type IS XPathValueType::Boolean) {
+         bool node_boolean = node_value.to_boolean();
+         bool other_boolean = other_value.to_boolean();
+         double node_number = node_boolean ? 1.0 : 0.0;
+         double other_number = other_boolean ? 1.0 : 0.0;
+         return numeric_compare(node_number, other_number, Operation);
+      }
+
+      double other_number = other_value.to_number();
+      if (std::isnan(other_number)) return false;
+
+      for (size_t index = 0; index < node_value.node_set.size(); ++index) {
+         double node_number = node_set_number_value(node_value, index);
+         if (std::isnan(node_number)) continue;
+         if (numeric_compare(node_number, other_number, Operation)) return true;
+      }
+
+      return false;
+   }
+
+   double left_number = left_value.to_number();
+   double right_number = right_value.to_number();
+   return numeric_compare(left_number, right_number, Operation);
 }
 
 } // namespace
@@ -1239,6 +1318,8 @@ XPathValue SimpleXPathEvaluator::evaluate_path_expression_value(const XPathNode 
       return XPathValue();
    }
 
+   axis_evaluator.normalise_node_set(node_results);
+
    if (context.attribute_node and (steps.size() IS 1)) {
       const XPathNode *step = steps[0];
       const XPathNode *axis_node = nullptr;
@@ -1295,6 +1376,66 @@ XPathValue SimpleXPathEvaluator::evaluate_path_expression_value(const XPathNode 
    return XPathValue(node_results);
 }
 
+XPathValue SimpleXPathEvaluator::evaluate_path_from_nodes(const std::vector<XMLTag *> &InitialContext,
+                                                          const std::vector<const XPathNode *> &Steps,
+                                                          const XPathNode *AttributeStep,
+                                                          const XPathNode *AttributeTest,
+                                                          uint32_t CurrentPrefix)
+{
+   std::vector<const XPathNode *> work_steps = Steps;
+
+   if (AttributeStep and !work_steps.empty()) work_steps.pop_back();
+
+   std::vector<XMLTag *> node_results;
+
+   if (work_steps.empty()) {
+      node_results = InitialContext;
+   }
+   else {
+      std::vector<AxisMatch> initial_matches;
+      initial_matches.reserve(InitialContext.size());
+
+      for (auto *candidate : InitialContext) {
+         initial_matches.push_back({ candidate, nullptr });
+      }
+
+      bool unsupported = false;
+      node_results = collect_step_results(initial_matches, work_steps, 0, CurrentPrefix, unsupported);
+
+      if (unsupported) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+   }
+
+   axis_evaluator.normalise_node_set(node_results);
+
+   if (AttributeStep) {
+      std::vector<std::string> attribute_values;
+      std::vector<XMLTag *> attribute_nodes;
+
+      for (auto *candidate : node_results) {
+         if (!candidate) continue;
+
+         auto matches = dispatch_axis(AxisType::Attribute, candidate);
+         for (auto &match : matches) {
+            if (!match.attribute) continue;
+            if (!match_node_test(AttributeTest, AxisType::Attribute, match.node, match.attribute, CurrentPrefix)) continue;
+            attribute_values.push_back(match.attribute->Value);
+            attribute_nodes.push_back(match.node);
+         }
+      }
+
+      if (attribute_nodes.empty()) return XPathValue(attribute_nodes);
+
+      std::optional<std::string> first_value;
+      if (!attribute_values.empty()) first_value = attribute_values[0];
+      return XPathValue(attribute_nodes, first_value, std::move(attribute_values));
+   }
+
+   return XPathValue(node_results);
+}
+
 XPathValue SimpleXPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32_t CurrentPrefix) {
    if (!ExprNode) {
       expression_unsupported = true;
@@ -1312,8 +1453,135 @@ XPathValue SimpleXPathEvaluator::evaluate_expression(const XPathNode *ExprNode, 
       return XPathValue(ExprNode->value);
    }
 
-   if ((ExprNode->type IS XPathNodeType::Path) or (ExprNode->type IS XPathNodeType::LocationPath)) {
+   if (ExprNode->type IS XPathNodeType::LocationPath) {
       return evaluate_path_expression_value(ExprNode, CurrentPrefix);
+   }
+
+   if (ExprNode->type IS XPathNodeType::Filter) {
+      if (ExprNode->child_count() IS 0) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      auto base_value = evaluate_expression(ExprNode->get_child(0), CurrentPrefix);
+      if (expression_unsupported) return XPathValue();
+
+      if (base_value.type != XPathValueType::NodeSet) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      std::vector<size_t> working_indices(base_value.node_set.size());
+      for (size_t index = 0; index < working_indices.size(); ++index) {
+         working_indices[index] = index;
+      }
+
+      for (size_t predicate_index = 1; predicate_index < ExprNode->child_count(); ++predicate_index) {
+         auto *predicate_node = ExprNode->get_child(predicate_index);
+         if (!predicate_node) continue;
+
+         std::vector<size_t> passed;
+         passed.reserve(working_indices.size());
+
+         for (size_t position = 0; position < working_indices.size(); ++position) {
+            size_t base_index = working_indices[position];
+            XMLTag *candidate = base_value.node_set[base_index];
+
+            push_context(candidate, position + 1, working_indices.size());
+            auto predicate_result = evaluate_predicate(predicate_node, CurrentPrefix);
+            pop_context();
+
+            if (predicate_result IS PredicateResult::Unsupported) {
+               expression_unsupported = true;
+               return XPathValue();
+            }
+
+            if (predicate_result IS PredicateResult::Match) passed.push_back(base_index);
+         }
+
+         working_indices.swap(passed);
+         if (working_indices.empty()) break;
+      }
+
+      std::vector<XMLTag *> filtered_nodes;
+      filtered_nodes.reserve(working_indices.size());
+
+      std::vector<std::string> filtered_strings;
+      filtered_strings.reserve(working_indices.size());
+
+      for (size_t index : working_indices) {
+         filtered_nodes.push_back(base_value.node_set[index]);
+         if (index < base_value.node_set_string_values.size()) {
+            filtered_strings.push_back(base_value.node_set_string_values[index]);
+         }
+      }
+
+      std::optional<std::string> first_value;
+      if (!working_indices.empty()) {
+         size_t first_index = working_indices[0];
+         if (base_value.node_set_string_override.has_value() and (first_index IS 0)) {
+            first_value = base_value.node_set_string_override;
+         }
+         else if (first_index < base_value.node_set_string_values.size()) {
+            first_value = base_value.node_set_string_values[first_index];
+         }
+      }
+
+      return XPathValue(filtered_nodes, first_value, std::move(filtered_strings));
+   }
+
+   if (ExprNode->type IS XPathNodeType::Path) {
+      if (ExprNode->child_count() IS 0) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      auto *first_child = ExprNode->get_child(0);
+      if (first_child and (first_child->type IS XPathNodeType::LocationPath)) {
+         return evaluate_path_expression_value(ExprNode, CurrentPrefix);
+      }
+
+      auto base_value = evaluate_expression(first_child, CurrentPrefix);
+      if (expression_unsupported) return XPathValue();
+
+      if (base_value.type != XPathValueType::NodeSet) {
+         return XPathValue(base_value.to_node_set());
+      }
+
+      std::vector<const XPathNode *> steps;
+      for (size_t index = 1; index < ExprNode->child_count(); ++index) {
+         auto *child = ExprNode->get_child(index);
+         if (child and (child->type IS XPathNodeType::Step)) steps.push_back(child);
+      }
+
+      if (steps.empty()) return base_value;
+
+      const XPathNode *attribute_step = nullptr;
+      const XPathNode *attribute_test = nullptr;
+
+      if (!steps.empty()) {
+         auto *last_step = steps.back();
+         const XPathNode *axis_node = nullptr;
+         const XPathNode *node_test = nullptr;
+
+         for (size_t index = 0; index < last_step->child_count(); ++index) {
+            auto *child = last_step->get_child(index);
+            if (!child) continue;
+
+            if (child->type IS XPathNodeType::AxisSpecifier) axis_node = child;
+            else if ((!node_test) and ((child->type IS XPathNodeType::NameTest) or
+                                       (child->type IS XPathNodeType::Wildcard) or
+                                       (child->type IS XPathNodeType::NodeTypeTest))) node_test = child;
+         }
+
+         AxisType axis = axis_node ? AxisEvaluator::parse_axis_name(axis_node->value) : AxisType::Child;
+         if (axis IS AxisType::Attribute) {
+            attribute_step = last_step;
+            attribute_test = node_test;
+         }
+      }
+
+      return evaluate_path_from_nodes(base_value.node_set, steps, attribute_step, attribute_test, CurrentPrefix);
    }
 
    if (ExprNode->type IS XPathNodeType::FunctionCall) {
@@ -1398,31 +1666,23 @@ XPathValue SimpleXPathEvaluator::evaluate_expression(const XPathNode *ExprNode, 
       }
 
       if (operation IS "<") {
-         double left_number = left_value.to_number();
-         double right_number = right_value.to_number();
-         if (std::isnan(left_number) or std::isnan(right_number)) return XPathValue(false);
-         return XPathValue(left_number < right_number);
+         bool result = compare_xpath_relational(left_value, right_value, RelationalOperator::Less);
+         return XPathValue(result);
       }
 
       if (operation IS "<=") {
-         double left_number = left_value.to_number();
-         double right_number = right_value.to_number();
-         if (std::isnan(left_number) or std::isnan(right_number)) return XPathValue(false);
-         return XPathValue(left_number <= right_number);
+         bool result = compare_xpath_relational(left_value, right_value, RelationalOperator::LessOrEqual);
+         return XPathValue(result);
       }
 
       if (operation IS ">") {
-         double left_number = left_value.to_number();
-         double right_number = right_value.to_number();
-         if (std::isnan(left_number) or std::isnan(right_number)) return XPathValue(false);
-         return XPathValue(left_number > right_number);
+         bool result = compare_xpath_relational(left_value, right_value, RelationalOperator::Greater);
+         return XPathValue(result);
       }
 
       if (operation IS ">=") {
-         double left_number = left_value.to_number();
-         double right_number = right_value.to_number();
-         if (std::isnan(left_number) or std::isnan(right_number)) return XPathValue(false);
-         return XPathValue(left_number >= right_number);
+         bool result = compare_xpath_relational(left_value, right_value, RelationalOperator::GreaterOrEqual);
+         return XPathValue(result);
       }
 
       if (operation IS "+") {
@@ -1456,22 +1716,13 @@ XPathValue SimpleXPathEvaluator::evaluate_expression(const XPathNode *ExprNode, 
          auto left_nodes = left_value.to_node_set();
          auto right_nodes = right_value.to_node_set();
 
-         std::unordered_set<XMLTag *> seen;
-         seen.reserve(left_nodes.size() + right_nodes.size());
-
          std::vector<XMLTag *> combined;
          combined.reserve(left_nodes.size() + right_nodes.size());
 
-         for (auto *node : left_nodes) {
-            if (!seen.insert(node).second) continue;
-            combined.push_back(node);
-         }
+         for (auto *node : left_nodes) combined.push_back(node);
+         for (auto *node : right_nodes) combined.push_back(node);
 
-         for (auto *node : right_nodes) {
-            if (!seen.insert(node).second) continue;
-            combined.push_back(node);
-         }
-
+         axis_evaluator.normalise_node_set(combined);
          return XPathValue(combined);
       }
 
@@ -1493,6 +1744,99 @@ XPathValue SimpleXPathEvaluator::evaluate_expression(const XPathNode *ExprNode, 
 
    expression_unsupported = true;
    return XPathValue();
+}
+
+ERR SimpleXPathEvaluator::process_expression_node_set(const std::vector<XMLTag *> &Nodes)
+{
+   std::vector<XMLTag *> ordered = Nodes;
+   axis_evaluator.normalise_node_set(ordered);
+
+   bool matched = false;
+
+   for (size_t index = 0; index < ordered.size(); ++index) {
+      auto *candidate = ordered[index];
+      push_context(candidate, index + 1, ordered.size());
+
+      if (!candidate) {
+         pop_context();
+         continue;
+      }
+
+      auto tags = xml->getInsert(candidate, xml->Cursor);
+      if (!tags) {
+         pop_context();
+         continue;
+      }
+
+      xml->CursorTags = tags;
+      xml->Attrib.clear();
+
+      if (!xml->Callback.defined()) {
+         pop_context();
+         return ERR::Okay;
+      }
+
+      push_cursor_state();
+
+      ERR callback_error = ERR::Okay;
+      if (xml->Callback.isC()) {
+         auto routine = (ERR (*)(extXML *, int, CSTRING, APTR))xml->Callback.Routine;
+         callback_error = routine(xml, candidate->ID, xml->Attrib.empty() ? nullptr : xml->Attrib.c_str(), xml->Callback.Meta);
+      }
+      else if (xml->Callback.isScript()) {
+         if (sc::Call(xml->Callback, std::to_array<ScriptArg>({
+            { "XML",  xml, FD_OBJECTPTR },
+            { "Tag",  candidate->ID },
+            { "Attrib", xml->Attrib.empty() ? CSTRING(nullptr) : xml->Attrib.c_str() }
+         }), callback_error) != ERR::Okay) callback_error = ERR::Terminate;
+      }
+      else callback_error = ERR::InvalidValue;
+
+      pop_cursor_state();
+      pop_context();
+
+      matched = true;
+
+      if (callback_error IS ERR::Terminate) return ERR::Terminate;
+      if (callback_error != ERR::Okay) return callback_error;
+   }
+
+   xml->Attrib.clear();
+   if (matched) return ERR::Okay;
+   return ERR::Search;
+}
+
+ERR SimpleXPathEvaluator::evaluate_top_level_expression(const XPathNode *Node, uint32_t CurrentPrefix)
+{
+   if (!Node) return ERR::Failed;
+
+   const XPathNode *expression = Node;
+
+   if (Node->type IS XPathNodeType::Expression) {
+      if (Node->child_count() IS 0) {
+         xml->Attrib.clear();
+         return ERR::Search;
+      }
+
+      expression = Node->get_child(0);
+   }
+
+   expression_unsupported = false;
+   auto value = evaluate_expression(expression, CurrentPrefix);
+   if (expression_unsupported) return ERR::Failed;
+
+   switch (value.type) {
+      case XPathValueType::NodeSet:
+         return process_expression_node_set(value.to_node_set());
+
+      case XPathValueType::Boolean:
+      case XPathValueType::Number:
+      case XPathValueType::String:
+         xml->Attrib = value.to_string();
+         return ERR::Okay;
+   }
+
+   return ERR::Failed;
 }
 
 XPathValue SimpleXPathEvaluator::evaluate_function_call(const XPathNode *FuncNode, uint32_t CurrentPrefix) {

--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -45,9 +45,16 @@ class SimpleXPathEvaluator {
                                               uint32_t CurrentPrefix,
                                               bool &Unsupported);
    XPathValue evaluate_path_expression_value(const XPathNode *PathNode, uint32_t CurrentPrefix);
+   XPathValue evaluate_path_from_nodes(const std::vector<XMLTag *> &InitialContext,
+                                       const std::vector<const XPathNode *> &Steps,
+                                       const XPathNode *AttributeStep,
+                                       const XPathNode *AttributeTest,
+                                       uint32_t CurrentPrefix);
+   ERR evaluate_top_level_expression(const XPathNode *Node, uint32_t CurrentPrefix);
+   ERR process_expression_node_set(const std::vector<XMLTag *> &Nodes);
 
    public:
-   explicit SimpleXPathEvaluator(extXML *XML) : xml(XML), axis_evaluator(XML) {}
+   explicit SimpleXPathEvaluator(extXML *XML) : xml(XML), axis_evaluator(XML) { context.document = XML; }
 
    // Phase 2+ methods (AST-based)
    ERR evaluate_ast(const XPathNode *Node, uint32_t CurrentPrefix);

--- a/src/xml/xpath/xpath_functions.cpp
+++ b/src/xml/xpath/xpath_functions.cpp
@@ -1,7 +1,46 @@
 // XPath Function Library and Value System Implementation
 
+#include "xpath_functions.h"
+#include "../xml.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cctype>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+#include <unordered_set>
+
 //********************************************************************************************************************
 // XPathValue Implementation
+
+namespace {
+
+std::string format_xpath_number(double Value)
+{
+   if (std::isnan(Value)) return std::string("NaN");
+   if (std::isinf(Value)) return (Value > 0) ? std::string("Infinity") : std::string("-Infinity");
+   if (Value IS 0.0) return std::string("0");
+
+   std::ostringstream stream;
+   stream.setf(std::ios::fmtflags(0), std::ios::floatfield);
+   stream.precision(15);
+   stream << Value;
+
+   std::string result = stream.str();
+
+   if (!result.empty() and (result[0] IS '+')) result.erase(result.begin());
+
+   auto decimal = result.find('.');
+   if (decimal != std::string::npos) {
+      while ((!result.empty()) and (result.back() IS '0')) result.pop_back();
+      if ((!result.empty()) and (result.back() IS '.')) result.pop_back();
+   }
+
+   return result;
+}
+
+} // namespace
 
 bool XPathValue::to_boolean() const {
    switch (type) {
@@ -13,29 +52,44 @@ bool XPathValue::to_boolean() const {
    return false;
 }
 
+double XPathValue::string_to_number(const std::string &Value)
+{
+   if (Value.empty()) return std::numeric_limits<double>::quiet_NaN();
+
+   char *end_ptr = nullptr;
+   double result = std::strtod(Value.c_str(), &end_ptr);
+   if ((end_ptr IS Value.c_str()) or (*end_ptr != '\0')) {
+      return std::numeric_limits<double>::quiet_NaN();
+   }
+
+   return result;
+}
+
+std::string XPathValue::node_string_value(XMLTag *Node)
+{
+   if (!Node) return std::string();
+
+   if (Node->isContent()) {
+      if (!Node->Children.empty()) return Node->getContent();
+      if (!Node->Attribs.empty()) return Node->Attribs[0].Value;
+      return std::string();
+   }
+
+   return Node->getContent();
+}
+
 double XPathValue::to_number() const {
    switch (type) {
       case XPathValueType::Boolean: return boolean_value ? 1.0 : 0.0;
       case XPathValueType::Number: return number_value;
       case XPathValueType::String: {
-         if (string_value.empty()) return std::numeric_limits<double>::quiet_NaN();
-         char* end_ptr = nullptr;
-         double result = std::strtod(string_value.c_str(), &end_ptr);
-         if (end_ptr IS string_value.c_str() or *end_ptr != '\0') {
-            return std::numeric_limits<double>::quiet_NaN();
-         }
-         return result;
+         return string_to_number(string_value);
       }
       case XPathValueType::NodeSet: {
          if (node_set.empty()) return std::numeric_limits<double>::quiet_NaN();
-         std::string str = to_string();
-         if (str.empty()) return std::numeric_limits<double>::quiet_NaN();
-         char* end_ptr = nullptr;
-         double result = std::strtod(str.c_str(), &end_ptr);
-         if (end_ptr IS str.c_str() or *end_ptr != '\0') {
-            return std::numeric_limits<double>::quiet_NaN();
-         }
-         return result;
+         if (node_set_string_override.has_value()) return string_to_number(*node_set_string_override);
+         if (!node_set_string_values.empty()) return string_to_number(node_set_string_values[0]);
+         return string_to_number(node_string_value(node_set[0]));
       }
    }
    return 0.0;
@@ -45,12 +99,7 @@ std::string XPathValue::to_string() const {
    switch (type) {
       case XPathValueType::Boolean: return boolean_value ? "true" : "false";
       case XPathValueType::Number: {
-         if (std::isnan(number_value)) return "NaN";
-         if (std::isinf(number_value)) return number_value > 0 ? "Infinity" : "-Infinity";
-         if (number_value IS std::floor(number_value)) {
-            return std::to_string((long long)number_value);
-         }
-         return std::to_string(number_value);
+         return format_xpath_number(number_value);
       }
       case XPathValueType::String: return string_value;
       case XPathValueType::NodeSet: {
@@ -58,17 +107,7 @@ std::string XPathValue::to_string() const {
          if (!node_set_string_values.empty()) return node_set_string_values[0];
          if (node_set.empty()) return "";
 
-         XMLTag *tag = node_set[0];
-         if (!tag) return "";
-
-         if (tag->isContent()) {
-            if (!tag->Attribs.empty() && !tag->Attribs[0].Value.empty()) {
-               return tag->Attribs[0].Value;
-            }
-            return tag->getContent();
-         }
-
-         return tag->getContent();
+         return node_string_value(node_set[0]);
       }
    }
    return "";
@@ -97,6 +136,77 @@ size_t XPathValue::size() const {
       default: return is_empty() ? 0 : 1;
    }
 }
+
+namespace {
+
+std::string find_in_scope_namespace(XMLTag *Node, extXML *Document, const std::string &Prefix)
+{
+   XMLTag *current = Node;
+
+   while (current) {
+      for (size_t index = 1; index < current->Attribs.size(); ++index) {
+         const auto &attrib = current->Attribs[index];
+
+         if (Prefix.empty()) {
+            if ((attrib.Name.length() IS 5) and (attrib.Name.compare(0, 5, "xmlns") IS 0)) return attrib.Value;
+         }
+         else {
+            if (attrib.Name.compare(0, 6, "xmlns:") IS 0) {
+               std::string declared = attrib.Name.substr(6);
+               if ((declared.length() IS Prefix.length()) and (declared.compare(Prefix) IS 0)) return attrib.Value;
+            }
+         }
+      }
+
+      if (!Document) break;
+      if (current->ParentID IS 0) break;
+      current = Document->getTag(current->ParentID);
+   }
+
+   return std::string();
+}
+
+std::string find_language_for_node(XMLTag *Node, extXML *Document)
+{
+   XMLTag *current = Node;
+
+   while (current) {
+      for (size_t index = 1; index < current->Attribs.size(); ++index) {
+         const auto &attrib = current->Attribs[index];
+         if (pf::iequals(attrib.Name, "xml:lang")) return attrib.Value;
+      }
+
+      if (!Document) break;
+      if (current->ParentID IS 0) break;
+      current = Document->getTag(current->ParentID);
+   }
+
+   return std::string();
+}
+
+std::string lowercase_copy(const std::string &Value)
+{
+   std::string result = Value;
+   std::transform(result.begin(), result.end(), result.begin(), [](unsigned char Ch) { return char(std::tolower(Ch)); });
+   return result;
+}
+
+bool language_matches(const std::string &Candidate, const std::string &Requested)
+{
+   if (Requested.empty()) return false;
+
+   std::string candidate_lower = lowercase_copy(Candidate);
+   std::string requested_lower = lowercase_copy(Requested);
+
+   if (candidate_lower.compare(0, requested_lower.length(), requested_lower) IS 0) {
+      if (candidate_lower.length() IS requested_lower.length()) return true;
+      if ((candidate_lower.length() > requested_lower.length()) and (candidate_lower[requested_lower.length()] IS '-')) return true;
+   }
+
+   return false;
+}
+
+} // namespace
 
 //********************************************************************************************************************
 // XPathFunctionLibrary Implementation
@@ -178,23 +288,179 @@ XPathValue XPathFunctionLibrary::function_count(const std::vector<XPathValue> &A
 }
 
 XPathValue XPathFunctionLibrary::function_id(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement ID function properly
-   return XPathValue();
+   std::vector<XMLTag *> results;
+
+   if (Args.empty()) return XPathValue(results);
+
+   std::unordered_set<std::string> requested_ids;
+
+   auto add_tokens = [&](const std::string &Value) {
+      size_t start = Value.find_first_not_of(" \t\r\n");
+      while (start != std::string::npos) {
+         size_t end = Value.find_first_of(" \t\r\n", start);
+         std::string token = Value.substr(start, (end IS std::string::npos) ? std::string::npos : end - start);
+         if (!token.empty()) requested_ids.insert(token);
+         if (end IS std::string::npos) break;
+         start = Value.find_first_not_of(" \t\r\n", end);
+      }
+   };
+
+   auto collect_from_value = [&](const XPathValue &Value) {
+      switch (Value.type) {
+         case XPathValueType::NodeSet: {
+            if (!Value.node_set_string_values.empty()) {
+               for (const auto &entry : Value.node_set_string_values) add_tokens(entry);
+            }
+            else if (Value.node_set_string_override.has_value()) add_tokens(*Value.node_set_string_override);
+            else {
+               for (auto *node : Value.node_set) {
+                  if (!node) continue;
+                  add_tokens(node->getContent());
+               }
+            }
+            break;
+         }
+
+         case XPathValueType::String:
+            add_tokens(Value.string_value);
+            break;
+
+         case XPathValueType::Boolean:
+            add_tokens(Value.to_string());
+            break;
+
+         case XPathValueType::Number:
+            if (!std::isnan(Value.number_value)) add_tokens(Value.to_string());
+            break;
+      }
+   };
+
+   for (const auto &arg : Args) collect_from_value(arg);
+
+   if (requested_ids.empty()) return XPathValue(results);
+   if (!Context.document) return XPathValue(results);
+
+   std::unordered_set<int> seen_tags;
+
+   std::function<void(XMLTag &)> visit = [&](XMLTag &Tag) {
+      if (Tag.isTag()) {
+         for (size_t index = 1; index < Tag.Attribs.size(); ++index) {
+            const auto &attrib = Tag.Attribs[index];
+            if (!(pf::iequals(attrib.Name, "id") or pf::iequals(attrib.Name, "xml:id"))) continue;
+
+            size_t start = attrib.Value.find_first_not_of(" \t\r\n");
+            while (start != std::string::npos) {
+               size_t end = attrib.Value.find_first_of(" \t\r\n", start);
+               std::string token = attrib.Value.substr(start, (end IS std::string::npos) ? std::string::npos : end - start);
+               if (!token.empty() and (requested_ids.find(token) != requested_ids.end())) {
+                  if (seen_tags.insert(Tag.ID).second) results.push_back(&Tag);
+                  break;
+               }
+               if (end IS std::string::npos) break;
+               start = attrib.Value.find_first_not_of(" \t\r\n", end);
+            }
+         }
+      }
+
+      for (auto &child : Tag.Children) visit(child);
+   };
+
+   for (auto &root : Context.document->Tags) visit(root);
+
+   return XPathValue(results);
 }
 
 XPathValue XPathFunctionLibrary::function_local_name(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement local-name function properly
-   return XPathValue("");
+   XMLTag *target_node = nullptr;
+   const XMLAttrib *target_attribute = nullptr;
+
+   if (Args.empty()) {
+      target_node = Context.context_node;
+      target_attribute = Context.attribute_node;
+   }
+   else if (Args[0].type IS XPathValueType::NodeSet) target_node = Args[0].node_set.empty() ? nullptr : Args[0].node_set[0];
+   else return XPathValue("");
+
+   if (target_attribute) {
+      std::string_view name = target_attribute->Name;
+      auto colon = name.find(':');
+      if (colon IS std::string::npos) return XPathValue(std::string(name));
+      return XPathValue(std::string(name.substr(colon + 1)));
+   }
+
+   if (!target_node) return XPathValue("");
+   if (target_node->Attribs.empty()) return XPathValue("");
+
+   std::string_view node_name = target_node->Attribs[0].Name;
+   if (node_name.empty()) return XPathValue("");
+
+   auto colon = node_name.find(':');
+   if (colon IS std::string::npos) return XPathValue(std::string(node_name));
+   return XPathValue(std::string(node_name.substr(colon + 1)));
 }
 
 XPathValue XPathFunctionLibrary::function_namespace_uri(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement namespace-uri function properly
+   XMLTag *target_node = nullptr;
+   const XMLAttrib *target_attribute = nullptr;
+
+   if (Args.empty()) {
+      target_node = Context.context_node;
+      target_attribute = Context.attribute_node;
+   }
+   else if (Args[0].type IS XPathValueType::NodeSet) target_node = Args[0].node_set.empty() ? nullptr : Args[0].node_set[0];
+   else return XPathValue("");
+
+   if (target_attribute) {
+      std::string_view name = target_attribute->Name;
+      auto colon = name.find(':');
+      if (colon IS std::string::npos) return XPathValue("");
+
+      std::string prefix(name.substr(0, colon));
+      if (pf::iequals(prefix, "xml")) return XPathValue("http://www.w3.org/XML/1998/namespace");
+      if (pf::iequals(prefix, "xmlns")) return XPathValue("http://www.w3.org/2000/xmlns/");
+
+      XMLTag *scope_node = target_node ? target_node : Context.context_node;
+      if (!scope_node) return XPathValue("");
+
+      if (Context.document) {
+         std::string uri = find_in_scope_namespace(scope_node, Context.document, prefix);
+         return XPathValue(uri);
+      }
+
+      return XPathValue("");
+   }
+
+   if (!target_node) return XPathValue("");
+
+   if ((target_node->NamespaceID != 0) and Context.document) {
+      if (auto uri = Context.document->getNamespaceURI(target_node->NamespaceID)) return XPathValue(*uri);
+   }
+
+   if (Context.document) {
+      std::string uri = find_in_scope_namespace(target_node, Context.document, std::string());
+      return XPathValue(uri);
+   }
+
    return XPathValue("");
 }
 
 XPathValue XPathFunctionLibrary::function_name(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement name function properly
-   return XPathValue("");
+   XMLTag *target_node = nullptr;
+   const XMLAttrib *target_attribute = nullptr;
+
+   if (Args.empty()) {
+      target_node = Context.context_node;
+      target_attribute = Context.attribute_node;
+   }
+   else if (Args[0].type IS XPathValueType::NodeSet) target_node = Args[0].node_set.empty() ? nullptr : Args[0].node_set[0];
+   else return XPathValue("");
+
+   if (target_attribute) return XPathValue(target_attribute->Name);
+
+   if (!target_node) return XPathValue("");
+   if (target_node->Attribs.empty()) return XPathValue("");
+
+   return XPathValue(target_node->Attribs[0].Name);
 }
 
 XPathValue XPathFunctionLibrary::function_string(const std::vector<XPathValue> &Args, const XPathContext &Context) {
@@ -236,13 +502,31 @@ XPathValue XPathFunctionLibrary::function_contains(const std::vector<XPathValue>
 }
 
 XPathValue XPathFunctionLibrary::function_substring_before(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement substring-before function
-   return XPathValue("");
+   if (Args.size() != 2) return XPathValue("");
+
+   std::string source = Args[0].to_string();
+   std::string pattern = Args[1].to_string();
+
+   if (pattern.empty()) return XPathValue("");
+
+   size_t position = source.find(pattern);
+   if (position IS std::string::npos) return XPathValue("");
+
+   return XPathValue(source.substr(0, position));
 }
 
 XPathValue XPathFunctionLibrary::function_substring_after(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement substring-after function
-   return XPathValue("");
+   if (Args.size() != 2) return XPathValue("");
+
+   std::string source = Args[0].to_string();
+   std::string pattern = Args[1].to_string();
+
+   if (pattern.empty()) return XPathValue(source);
+
+   size_t position = source.find(pattern);
+   if (position IS std::string::npos) return XPathValue("");
+
+   return XPathValue(source.substr(position + pattern.length()));
 }
 
 XPathValue XPathFunctionLibrary::function_substring(const std::vector<XPathValue> &Args, const XPathContext &Context) {
@@ -258,7 +542,7 @@ XPathValue XPathFunctionLibrary::function_substring(const std::vector<XPathValue
    if (start_index < 0) start_index = 0;
    if (start_index >= (int)str.length()) return XPathValue("");
 
-   if (Args.size() == 3) {
+   if (Args.size() IS 3) {
       double length = Args[2].to_number();
       if (std::isnan(length) or std::isinf(length) or length <= 0) return XPathValue("");
       int len = (int)std::round(length);
@@ -296,7 +580,7 @@ XPathValue XPathFunctionLibrary::function_normalize_space(const std::vector<XPat
 
    // Remove leading and trailing whitespace, collapse internal whitespace
    size_t start = str.find_first_not_of(" \t\n\r");
-   if (start == std::string::npos) return XPathValue("");
+   if (start IS std::string::npos) return XPathValue("");
 
    size_t end = str.find_last_not_of(" \t\n\r");
    str = str.substr(start, end - start + 1);
@@ -305,7 +589,7 @@ XPathValue XPathFunctionLibrary::function_normalize_space(const std::vector<XPat
    std::string result;
    bool in_whitespace = false;
    for (char c : str) {
-      if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
+      if (c IS ' ' or c IS '\t' or c IS '\n' or c IS '\r') {
          if (!in_whitespace) {
             result += ' ';
             in_whitespace = true;
@@ -320,8 +604,26 @@ XPathValue XPathFunctionLibrary::function_normalize_space(const std::vector<XPat
 }
 
 XPathValue XPathFunctionLibrary::function_translate(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement translate function
-   return XPathValue("");
+   if (Args.size() != 3) return XPathValue("");
+
+   std::string source = Args[0].to_string();
+   std::string from = Args[1].to_string();
+   std::string to = Args[2].to_string();
+
+   std::string result;
+   result.reserve(source.size());
+
+   for (char ch : source) {
+      size_t index = from.find(ch);
+      if (index IS std::string::npos) {
+         result.push_back(ch);
+         continue;
+      }
+
+      if (index < to.length()) result.push_back(to[index]);
+   }
+
+   return XPathValue(result);
 }
 
 XPathValue XPathFunctionLibrary::function_boolean(const std::vector<XPathValue> &Args, const XPathContext &Context) {
@@ -343,8 +645,18 @@ XPathValue XPathFunctionLibrary::function_false(const std::vector<XPathValue> &A
 }
 
 XPathValue XPathFunctionLibrary::function_lang(const std::vector<XPathValue> &Args, const XPathContext &Context) {
-   // TODO: Implement lang function
-   return XPathValue(false);
+   if (Args.size() != 1) return XPathValue(false);
+
+   std::string requested = Args[0].to_string();
+   if (requested.empty()) return XPathValue(false);
+
+   XMLTag *node = Context.context_node;
+   if (!node) return XPathValue(false);
+
+   std::string language = find_language_for_node(node, Context.document);
+   if (language.empty()) return XPathValue(false);
+
+   return XPathValue(language_matches(language, requested));
 }
 
 XPathValue XPathFunctionLibrary::function_number(const std::vector<XPathValue> &Args, const XPathContext &Context) {

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -16,6 +16,7 @@
 
 struct XMLTag;
 struct XMLAttrib;
+class extXML;
 
 //********************************************************************************************************************
 // XPath Value System
@@ -59,6 +60,10 @@ class XPathValue {
    // Utility methods
    bool is_empty() const;
    size_t size() const;
+
+   // Helpers exposed for evaluator utilities
+   static std::string node_string_value(XMLTag *Node);
+   static double string_to_number(const std::string &Value);
 };
 
 //********************************************************************************************************************
@@ -70,10 +75,19 @@ struct XPathContext {
    size_t position = 1;
    size_t size = 1;
    std::map<std::string, XPathValue> variables;
+   extXML * document = nullptr;
 
    XPathContext() = default;
-   XPathContext(XMLTag *Node, size_t Pos = 1, size_t Sz = 1, const XMLAttrib *Attribute = nullptr)
-      : context_node(Node), attribute_node(Attribute), position(Pos), size(Sz) {}
+   XPathContext(XMLTag *Node,
+                size_t Pos = 1,
+                size_t Sz = 1,
+                const XMLAttrib *Attribute = nullptr,
+                extXML *Document = nullptr)
+      : context_node(Node),
+        attribute_node(Attribute),
+        position(Pos),
+        size(Sz),
+        document(Document) {}
 };
 
 //********************************************************************************************************************


### PR DESCRIPTION
## Summary
- allow the XPath parser to return full expressions, introducing a filter node type and supporting predicates and relative paths after primary expressions
- teach the evaluator to execute filter expressions, expression-root ASTs, and paths that begin with arbitrary expressions by reusing step traversal helpers
- add helpers to evaluate relative paths from existing node-sets and to surface expression results (including node-sets) through the existing XPath API

## Testing
- cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/agents -DRUN_ANYWHERE=TRUE -DPARASOL_STATIC=OFF -DBUILD_DEFS=ON
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d456887704832eadfd1b2405927982