### PR TITLE
Fix attribute context propagation in XPath predicates

### DIFF
--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -1496,8 +1496,12 @@ XPathValue SimpleXPathEvaluator::evaluate_expression(const XPathNode *ExprNode, 
          for (size_t position = 0; position < working_indices.size(); ++position) {
             size_t base_index = working_indices[position];
             XMLTag *candidate = base_value.node_set[base_index];
+            const XMLAttrib *attribute = nullptr;
+            if (base_index < base_value.node_set_attributes.size()) {
+               attribute = base_value.node_set_attributes[base_index];
+            }
 
-            push_context(candidate, position + 1, working_indices.size());
+            push_context(candidate, position + 1, working_indices.size(), attribute);
             auto predicate_result = evaluate_predicate(predicate_node, CurrentPrefix);
             pop_context();
 


### PR DESCRIPTION
## Summary
- ensure XPath predicate evaluation preserves attribute metadata when iterating node-set items
- pass the corresponding attribute pointer into push_context so attribute axes/functions see the correct context

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d48201ec94832e903f24202d777cdb