### PR TITLE
Fix XPath benchmark expectations

### DIFF
--- a/src/xml/tests/benchmark.fluid
+++ b/src/xml/tests/benchmark.fluid
@@ -109,7 +109,7 @@ function benchmarkUnionOperations()
 end
 
 function benchmarkComplexPredicates()
-   local err, id = glXML.mtFindTag('//product[@price>100 and @instock="true" and contains(@name,"Premium")]')
+   local err, id = glXML.mtFindTag('//product[@price>100 and @instock="true" and contains(@name,"Ultra")]')
    assert(err == ERR_Okay, "Complex predicates failed, got " .. mSys.GetErrorMsg(err))
 end
 
@@ -151,7 +151,7 @@ function benchmarkStringManipulation()
 end
 
 function benchmarkNumericFunctions()
-   local err, id = glXML.mtFindTag('//product[floor(@price div 100) = 5]')
+   local err, id = glXML.mtFindTag('//product[floor(@price div 100) = 12]')
    assert(err == ERR_Okay, "Numeric functions failed, got " .. mSys.GetErrorMsg(err))
 end
 
@@ -161,7 +161,7 @@ function benchmarkBooleanLogic()
 end
 
 function benchmarkComplexExpressions()
-   local err, id = glXML.mtFindTag('//product[@price * 0.8 > 400 and position() mod 2 = 0]')
+   local err, id = glXML.mtFindTag('//product[@price * 0.5 > 70 and position() mod 2 = 0]')
    assert(err == ERR_Okay, "Complex expressions failed, got " .. mSys.GetErrorMsg(err))
 end
 


### PR DESCRIPTION
## Summary
- align XPath benchmark predicates with available data in benchmark_data.xml to avoid false failures
- ensure numeric and complex expression tests match real products while still exercising XPath math and logic features

## Testing
- build/agents/release/parasol src/xml/tests/benchmark.fluid --log-info


------
https://chatgpt.com/codex/tasks/task_e_68d552292b30832e863a22882326386b