### PR TITLE
Handle union nodes during XPath expression evaluation

### DIFF
--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -69,6 +69,7 @@ class SimpleXPathEvaluator {
                                        uint32_t CurrentPrefix);
    ERR evaluate_top_level_expression(const XPathNode *Node, uint32_t CurrentPrefix);
    ERR process_expression_node_set(const XPathValue &Value);
+   XPathValue evaluate_union_value(const std::vector<const XPathNode *> &Branches, uint32_t CurrentPrefix);
    ERR evaluate_union(const XPathNode *Node, uint32_t CurrentPrefix);
    std::shared_ptr<XPathNode> get_cached_ast(const std::string &Key);
    void store_cached_ast(const std::string &Key, const std::shared_ptr<XPathNode> &Ast, const std::string &Signature);


### PR DESCRIPTION
## Summary
- add a reusable helper that merges union branches into a document-ordered node-set while preserving attribute metadata
- update expression evaluation to route Union nodes and legacy binary `|` operations through the shared helper

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d5a56e8924832e85114dca25e8e101