### PR TITLE
Add XPath evaluation arena for pooled traversal buffers

### DIFF
--- a/src/xml/xpath/xpath_arena.h
+++ b/src/xml/xpath/xpath_arena.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+struct XMLTag;
+struct XMLAttrib;
+
+class XPathArena {
+   private:
+   template<typename T>
+   struct VectorPool {
+      std::vector<std::unique_ptr<std::vector<T>>> storage;
+      std::vector<std::vector<T> *> free_list;
+
+      std::vector<T> & acquire() {
+         if (!free_list.empty()) {
+            auto *vector = free_list.back();
+            free_list.pop_back();
+            vector->clear();
+            return *vector;
+         }
+
+         storage.push_back(std::make_unique<std::vector<T>>());
+         auto &vector = *storage.back();
+         vector.clear();
+         return vector;
+      }
+
+      void release(std::vector<T> &vector) {
+         vector.clear();
+         free_list.push_back(&vector);
+      }
+
+      void reset() {
+         free_list.clear();
+         for (auto &entry : storage) {
+            entry->clear();
+            free_list.push_back(entry.get());
+         }
+      }
+   };
+
+   VectorPool<XMLTag *> node_vectors;
+   VectorPool<const XMLAttrib *> attribute_vectors;
+   VectorPool<std::string> string_vectors;
+
+   public:
+   XPathArena() = default;
+   XPathArena(const XPathArena &) = delete;
+   XPathArena & operator=(const XPathArena &) = delete;
+
+   std::vector<XMLTag *> & acquire_node_vector() { return node_vectors.acquire(); }
+   void release_node_vector(std::vector<XMLTag *> &Vector) { node_vectors.release(Vector); }
+
+   std::vector<const XMLAttrib *> & acquire_attribute_vector() { return attribute_vectors.acquire(); }
+   void release_attribute_vector(std::vector<const XMLAttrib *> &Vector) { attribute_vectors.release(Vector); }
+
+   std::vector<std::string> & acquire_string_vector() { return string_vectors.acquire(); }
+   void release_string_vector(std::vector<std::string> &Vector) { string_vectors.release(Vector); }
+
+   void reset() {
+      node_vectors.reset();
+      attribute_vectors.reset();
+      string_vectors.reset();
+   }
+};

--- a/src/xml/xpath/xpath_axis.h
+++ b/src/xml/xpath/xpath_axis.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "xpath_ast.h"
+#include "xpath_arena.h"
 
 //********************************************************************************************************************
 // XPath Axis Types
@@ -34,6 +35,7 @@ enum class AxisType {
 class AxisEvaluator {
    private:
    extXML * xml;
+   XPathArena & arena;
    std::vector<std::unique_ptr<XMLTag>> namespace_node_storage;
    std::unordered_map<int, XMLTag *> id_lookup;
    bool id_cache_built = false;
@@ -56,19 +58,19 @@ class AxisEvaluator {
    std::vector<std::unique_ptr<XMLTag>> namespace_node_pool;
 
    // Helper methods for specific axes
-   std::vector<XMLTag *> evaluate_child_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_descendant_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_parent_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_ancestor_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_following_sibling_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_preceding_sibling_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_following_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_preceding_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_attribute_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_namespace_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_self_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_descendant_or_self_axis(XMLTag *ContextNode);
-   std::vector<XMLTag *> evaluate_ancestor_or_self_axis(XMLTag *ContextNode);
+   void evaluate_child_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_descendant_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_parent_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_ancestor_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_following_sibling_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_preceding_sibling_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_following_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_preceding_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_attribute_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_namespace_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_self_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_descendant_or_self_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
+   void evaluate_ancestor_or_self_axis(XMLTag *ContextNode, std::vector<XMLTag *> &Output);
 
    void collect_subtree_reverse(XMLTag *Node, std::vector<XMLTag *> &Output);
 
@@ -88,10 +90,10 @@ class AxisEvaluator {
    XMLTag * find_tag_by_id(int ID);
 
    public:
-   explicit AxisEvaluator(extXML *XML) : xml(XML) {}
+   explicit AxisEvaluator(extXML *XML, XPathArena &Arena) : xml(XML), arena(Arena) {}
 
    // Main evaluation method
-   std::vector<XMLTag *> evaluate_axis(AxisType Axis, XMLTag *ContextNode);
+   void evaluate_axis(AxisType Axis, XMLTag *ContextNode, std::vector<XMLTag *> &Output);
 
    // Evaluation lifecycle helpers
    void reset_namespace_nodes();

--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "xpath_arena.h"
+
 //********************************************************************************************************************
 // Main XPath Evaluator
 
@@ -24,6 +26,7 @@ class SimpleXPathEvaluator {
    extXML * xml;
    XPathFunctionLibrary function_library;
    XPathContext context;
+   XPathArena arena;
    AxisEvaluator axis_evaluator;
    bool expression_unsupported = false;
 
@@ -70,7 +73,7 @@ class SimpleXPathEvaluator {
    std::string build_ast_signature(const XPathNode *Node) const;
 
    public:
-   explicit SimpleXPathEvaluator(extXML *XML) : xml(XML), axis_evaluator(XML) { context.document = XML; }
+   explicit SimpleXPathEvaluator(extXML *XML) : xml(XML), axis_evaluator(XML, arena) { context.document = XML; }
 
    // Phase 2+ methods (AST-based)
    ERR evaluate_ast(const XPathNode *Node, uint32_t CurrentPrefix);


### PR DESCRIPTION
## Summary
- introduce a shared `XPathArena` for pooling transient XPath vectors
- update the axis and evaluator implementations to acquire and release arena buffers instead of returning temporary vectors
- reset arena state at the start of each evaluation to ensure reused storage is clean

## Testing
- `cmake --build build/agents --config Release --target xml -j 8`
- `cd build/agents/release && ./parasol ../../../src/xml/tests/benchmark.fluid --log-warning`


------
https://chatgpt.com/codex/tasks/task_e_68d678ad2138832eabebbc9d4033120a