### PR TITLE
Fix XPath '*' token classification outside predicates

### DIFF
--- a/src/xml/tests/test_xpath_predicates.fluid
+++ b/src/xml/tests/test_xpath_predicates.fluid
@@ -684,6 +684,26 @@ function testXPathArithmetic()
 
 -----------------------------------------------------------------------------------------------------------------------
 
+function testXPathMultiplicationOutsidePredicates()
+   local xml = obj.new("xml", {
+      statement = '<root><item price="3" tax="4"/><value>ignored</value></root>'
+   })
+
+   local err = xml.mtFindTag('3 * 4')
+   assert(err == ERR_Okay, 'Top-level multiplication should parse correctly: ' .. mSys.GetErrorMsg(err))
+
+   err = xml.mtFindTag('3 * 4 = 12')
+   assert(err == ERR_Okay, '3 * 4 should evaluate to 12 outside predicates: ' .. mSys.GetErrorMsg(err))
+
+   err = xml.mtFindTag('number(/root/item/@price) * number(/root/item/@tax) = 12')
+   assert(err == ERR_Okay, 'Attribute multiplication outside predicates should evaluate: ' .. mSys.GetErrorMsg(err))
+
+   err = xml.mtFindTag('substring("abcdef", 2 * 1, 3) = "bcd"')
+   assert(err == ERR_Okay, 'Function argument multiplication should parse: ' .. mSys.GetErrorMsg(err))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
 return {
    tests = {
       'testComparisonOperators', 'testMathematicalExpressions',
@@ -693,7 +713,7 @@ return {
       'testXPathNumberFunctions', 'testXPathExtendedNumberFunctions',
       'testEscapeCharacters', 'testEdgeCases', 'testPerformanceScenarios',
       'testFunctionLibrary', 'testXPathOperators',
-      'testXPathExpressions', 'testXPathArithmetic',
+      'testXPathExpressions', 'testXPathArithmetic', 'testXPathMultiplicationOutsidePredicates',
       'testXPathBooleanFunctions', 'testXPathIdFunction', 'testXPathNameFunctions'
    },
    init = function(ScriptFolder)


### PR DESCRIPTION
## Summary
- add a Flute regression test that exercises multiplication expressions outside of predicates
- adjust the XPath tokenizer to classify `*` as multiplication based on neighbouring operands instead of predicate depth

## Testing
- ./install/agents/parasol --gfx-driver=headless --log-warning tools/flute.fluid file=src/xml/tests/test_xpath_predicates.fluid

------
https://chatgpt.com/codex/tasks/task_e_68d69116fa34832ebb6f2cb7946e14cf