### PR TITLE
Fix XPath multiply context validation

### DIFF
--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -216,7 +216,25 @@ std::vector<XPathToken> XPathTokenizer::tokenize(std::string_view XPath) {
          };
 
          size_t operand_index = next_operand_index();
-         if (prev_is_operand and !prev_forces_wild and operand_index != std::string_view::npos) {
+         bool inside_structural_context = (bracket_depth > 0) or (paren_depth > 0);
+
+         bool prev_allows_binary = false;
+         if (!tokens.empty()) {
+            auto prev_type = tokens.back().type;
+
+            if ((prev_type IS XPathTokenType::IDENTIFIER) or
+                (prev_type IS XPathTokenType::RPAREN) or
+                (prev_type IS XPathTokenType::RBRACKET) or
+                (prev_type IS XPathTokenType::WILDCARD)) {
+               prev_allows_binary = true;
+            }
+            else if ((prev_type IS XPathTokenType::NUMBER) or (prev_type IS XPathTokenType::STRING)) {
+               if (inside_structural_context) prev_allows_binary = true;
+            }
+         }
+
+         if (prev_is_operand and prev_allows_binary and !prev_forces_wild and
+             operand_index != std::string_view::npos) {
             type = XPathTokenType::MULTIPLY;
          }
 


### PR DESCRIPTION
## Summary
- tighten the XPath tokenizer so `*` only becomes a multiply operator when the surrounding context allows a binary expression
- ensure bare arithmetic expressions like `3 * 4` are rejected while predicate and function contexts continue to parse correctly

## Testing
- cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/agents -DRUN_ANYWHERE=TRUE -DPARASOL_STATIC=OFF -DBUILD_DEFS=ON
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d6a462cd34832e99782e0e9b0beb08