### PR TITLE
Add XPath conditional and for expression support

### DIFF
--- a/src/xml/tests/test_xpath_advanced.fluid
+++ b/src/xml/tests/test_xpath_advanced.fluid
@@ -86,10 +86,10 @@ function testConditionalIfExpression()
       statement = '<root><item id="a">Alpha</item><item id="b">Beta</item></root>'
    })
 
-   local chosen = xml.getKey('if (/root/item[@id="a"]) then /root/item[@id="a"] else /root/item[@id="b"]')
+   local chosen = xml.getKey('xpath:if (/root/item[@id="a"]) then /root/item[@id="a"] else /root/item[@id="b"]')
    assert(chosen == 'Alpha', 'If expression should return Alpha branch when predicate succeeds, got ' .. nz(chosen, 'NIL'))
 
-   local fallback = xml.getKey('if (/root/item[@id="missing"]) then /root/item[@id="a"] else /root/item[@id="b"]')
+   local fallback = xml.getKey('xpath:if (/root/item[@id="missing"]) then /root/item[@id="a"] else /root/item[@id="b"]')
    assert(fallback == 'Beta', 'If expression should evaluate else branch when condition fails, got ' .. nz(fallback, 'NIL'))
 end
 

--- a/src/xml/tests/test_xpath_advanced.fluid
+++ b/src/xml/tests/test_xpath_advanced.fluid
@@ -79,9 +79,46 @@ function testDescendantAxisAttributeAccess()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
+-- Conditional expressions should select the correct branch
+
+function testConditionalIfExpression()
+   local xml = obj.new("xml", {
+      statement = '<root><item id="a">Alpha</item><item id="b">Beta</item></root>'
+   })
+
+   local chosen = xml.getKey('if (/root/item[@id="a"]) then /root/item[@id="a"] else /root/item[@id="b"]')
+   assert(chosen == 'Alpha', 'If expression should return Alpha branch when predicate succeeds, got ' .. nz(chosen, 'NIL'))
+
+   local fallback = xml.getKey('if (/root/item[@id="missing"]) then /root/item[@id="a"] else /root/item[@id="b"]')
+   assert(fallback == 'Beta', 'If expression should evaluate else branch when condition fails, got ' .. nz(fallback, 'NIL'))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- For expressions should iterate sequences and aggregate node results
+
+function testForExpressionNodeAggregation()
+   local xml = obj.new("xml", {
+      statement = '<root><group name="one"><item id="a">Alpha</item><item id="b">Beta</item></group><group name="two"><item id="c">Gamma</item></group></root>'
+   })
+
+   local collected = {}
+   local err, index = xml.mtFindTag('for $g in /root/group return $g/item', function(XML, TagID, Attrib)
+      local errAttr, idValue = xml.mtGetAttrib(TagID, 'id')
+      assert(errAttr == ERR_Okay, 'For expression callback should resolve item id: ' .. mSys.GetErrorMsg(errAttr))
+      table.insert(collected, idValue)
+   end)
+
+   assert(err == ERR_Okay, 'For expression evaluation should succeed: ' .. mSys.GetErrorMsg(err))
+   assert(#collected == 3, 'For expression should yield three items, got ' .. #collected)
+
+   table.sort(collected)
+   assert(collected[1] == 'a' and collected[2] == 'b' and collected[3] == 'c', 'For expression should gather all item identifiers, got ' .. table.concat(collected, ','))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
 return {
    tests = {
       'testDeeplyNestedPathTraversal', 'testSequentialPredicateEvaluation', 'testRelativeCurrentNodeTraversal',
-      'testMissingPathError', 'testDescendantAxisAttributeAccess'
+      'testMissingPathError', 'testDescendantAxisAttributeAccess', 'testConditionalIfExpression', 'testForExpressionNodeAggregation'
    }
 }

--- a/src/xml/xpath/xpath_ast.h
+++ b/src/xml/xpath/xpath_ast.h
@@ -53,6 +53,14 @@ enum class XPathTokenType {
    OR,                // or
    NOT,               // not
 
+   // Flow keywords
+   IF,                // if
+   THEN,              // then
+   ELSE,              // else
+   FOR,               // for
+   IN,                // in
+   RETURN,            // return
+
    // Arithmetic operators
    PLUS,              // +
    MINUS,             // -
@@ -108,6 +116,8 @@ enum class XPathNodeType {
    FILTER,
    BINARY_OP,
    UNARY_OP,
+   CONDITIONAL,
+   FOR_EXPRESSION,
    FUNCTION_CALL,
    LITERAL,
    VARIABLE_REFERENCE,

--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -1835,7 +1835,9 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
       std::vector<const XMLAttrib *> combined_attributes;
       std::optional<std::string> combined_override;
 
-      for (size_t index = 0; index < sequence_value.node_set.size(); ++index) {
+      size_t sequence_size = sequence_value.node_set.size();
+
+      for (size_t index = 0; index < sequence_size; ++index) {
          XMLTag *item_node = sequence_value.node_set[index];
          const XMLAttrib *item_attribute = nullptr;
          if (index < sequence_value.node_set_attributes.size()) {
@@ -1858,7 +1860,10 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
 
          context.variables[variable_name] = bound_value;
 
+         push_context(item_node, index + 1, sequence_size, item_attribute);
+         
          auto iteration_value = evaluate_expression(return_node, CurrentPrefix);
+         pop_context();
          if (expression_unsupported) {
             restore_variable();
             return XPathValue();

--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -1825,7 +1825,7 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
          previous_value = existing->second;
       }
 
-      auto restore_variable = [this, variable_name, had_previous, previous_value]() {
+      auto restore_variable = [this, variable_name, had_previous, &previous_value]() {
          if (had_previous) context.variables[variable_name] = previous_value;
          else context.variables.erase(variable_name);
       };

--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -416,6 +416,8 @@ ERR XPathEvaluator::evaluate_ast(const XPathNode *Node, uint32_t CurrentPrefix) 
       case XPathNodeType::VARIABLE_REFERENCE:
       case XPathNodeType::NUMBER:
       case XPathNodeType::STRING:
+      case XPathNodeType::CONDITIONAL:
+      case XPathNodeType::FOR_EXPRESSION:
          return evaluate_top_level_expression(Node, CurrentPrefix);
 
       default:
@@ -1768,6 +1770,143 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
       return evaluate_union_value(branches, CurrentPrefix);
    }
 
+   if (ExprNode->type IS XPathNodeType::CONDITIONAL) {
+      if (ExprNode->child_count() < 3) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      auto *condition_node = ExprNode->get_child(0);
+      auto *then_node = ExprNode->get_child(1);
+      auto *else_node = ExprNode->get_child(2);
+
+      if ((!condition_node) or (!then_node) or (!else_node)) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      auto condition_value = evaluate_expression(condition_node, CurrentPrefix);
+      if (expression_unsupported) return XPathValue();
+
+      bool condition_boolean = condition_value.to_boolean();
+      auto *selected_node = condition_boolean ? then_node : else_node;
+      auto branch_value = evaluate_expression(selected_node, CurrentPrefix);
+      return branch_value;
+   }
+
+   if (ExprNode->type IS XPathNodeType::FOR_EXPRESSION) {
+      if (ExprNode->child_count() < 2) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      const XPathNode *sequence_node = ExprNode->get_child(0);
+      const XPathNode *return_node = ExprNode->get_child(1);
+      const std::string variable_name = ExprNode->value;
+
+      if ((!sequence_node) or (!return_node) or variable_name.empty()) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      auto sequence_value = evaluate_expression(sequence_node, CurrentPrefix);
+      if (expression_unsupported) return XPathValue();
+
+      if (sequence_value.type != XPathValueType::NodeSet) {
+         expression_unsupported = true;
+         return XPathValue();
+      }
+
+      bool had_previous = false;
+      XPathValue previous_value;
+      auto existing = context.variables.find(variable_name);
+      if (existing != context.variables.end()) {
+         had_previous = true;
+         previous_value = existing->second;
+      }
+
+      auto restore_variable = [this, variable_name, had_previous, previous_value]() {
+         if (had_previous) context.variables[variable_name] = previous_value;
+         else context.variables.erase(variable_name);
+      };
+
+      std::vector<XMLTag *> combined_nodes;
+      std::vector<std::string> combined_strings;
+      std::vector<const XMLAttrib *> combined_attributes;
+      std::optional<std::string> combined_override;
+
+      for (size_t index = 0; index < sequence_value.node_set.size(); ++index) {
+         XMLTag *item_node = sequence_value.node_set[index];
+         const XMLAttrib *item_attribute = nullptr;
+         if (index < sequence_value.node_set_attributes.size()) {
+            item_attribute = sequence_value.node_set_attributes[index];
+         }
+
+         XPathValue bound_value;
+         bound_value.type = XPathValueType::NodeSet;
+         bound_value.node_set.push_back(item_node);
+         bound_value.node_set_attributes.push_back(item_attribute);
+
+         std::string item_string;
+         if (index < sequence_value.node_set_string_values.size()) {
+            item_string = sequence_value.node_set_string_values[index];
+         }
+         else if (item_node) item_string = XPathValue::node_string_value(item_node);
+
+         bound_value.node_set_string_values.push_back(item_string);
+         bound_value.node_set_string_override = item_string;
+
+         context.variables[variable_name] = bound_value;
+
+         auto iteration_value = evaluate_expression(return_node, CurrentPrefix);
+         if (expression_unsupported) {
+            restore_variable();
+            return XPathValue();
+         }
+
+         if (iteration_value.type != XPathValueType::NodeSet) {
+            restore_variable();
+            expression_unsupported = true;
+            return XPathValue();
+         }
+
+         for (size_t node_index = 0; node_index < iteration_value.node_set.size(); ++node_index) {
+            XMLTag *node = iteration_value.node_set[node_index];
+            combined_nodes.push_back(node);
+
+            const XMLAttrib *attribute = nullptr;
+            if (node_index < iteration_value.node_set_attributes.size()) {
+               attribute = iteration_value.node_set_attributes[node_index];
+            }
+            combined_attributes.push_back(attribute);
+
+            std::string node_string;
+            if (node_index < iteration_value.node_set_string_values.size()) {
+               node_string = iteration_value.node_set_string_values[node_index];
+            }
+            else if (node) node_string = XPathValue::node_string_value(node);
+
+            combined_strings.push_back(node_string);
+
+            if (!combined_override.has_value()) {
+               if (iteration_value.node_set_string_override.has_value()) combined_override = iteration_value.node_set_string_override;
+               else combined_override = node_string;
+            }
+         }
+      }
+
+      restore_variable();
+
+      XPathValue result;
+      result.type = XPathValueType::NodeSet;
+      result.node_set = std::move(combined_nodes);
+      result.node_set_string_values = std::move(combined_strings);
+      result.node_set_attributes = std::move(combined_attributes);
+      if (combined_override.has_value()) result.node_set_string_override = combined_override;
+      else result.node_set_string_override.reset();
+      return result;
+   }
+
    if (ExprNode->type IS XPathNodeType::FILTER) {
       if (ExprNode->child_count() IS 0) {
          expression_unsupported = true;
@@ -2101,6 +2240,11 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
    }
 
    if (ExprNode->type IS XPathNodeType::VARIABLE_REFERENCE) {
+      auto local_variable = context.variables.find(ExprNode->value);
+      if (local_variable != context.variables.end()) {
+         return local_variable->second;
+      }
+
       // Look up variable in the XML object's variable storage
       auto it = xml->Variables.find(ExprNode->value);
       if (it != xml->Variables.end()) {

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -1124,6 +1124,7 @@ std::unique_ptr<XPathNode> XPathParser::parse_for_expr() {
 
    if (!match(XPathTokenType::IN)) {
       report_error("Expected 'in' in for expression");
+      return nullptr;
    }
 
    auto sequence_expr = parse_expr();

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -1070,6 +1070,9 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
       report_error("Expected '(' after 'if'");
       return nullptr;
    }
+      report_error("Expected '(' after 'if'");
+      return nullptr;
+   }
 
    auto condition = parse_expr();
 
@@ -1087,6 +1090,7 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
 
    if (!match(XPathTokenType::ELSE)) {
       report_error("Expected 'else' in if expression");
+      return nullptr;
       return nullptr;
       return nullptr;
    }

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -1067,6 +1067,9 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
       report_error("Expected '(' after 'if'");
       return nullptr;
    }
+      report_error("Expected '(' after 'if'");
+      return nullptr;
+   }
 
    auto condition = parse_expr();
 
@@ -1084,6 +1087,7 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
 
    if (!match(XPathTokenType::ELSE)) {
       report_error("Expected 'else' in if expression");
+      return nullptr;
       return nullptr;
    }
 

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -1073,6 +1073,9 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
       report_error("Expected '(' after 'if'");
       return nullptr;
    }
+      report_error("Expected '(' after 'if'");
+      return nullptr;
+   }
 
    auto condition = parse_expr();
 
@@ -1090,6 +1093,7 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
 
    if (!match(XPathTokenType::ELSE)) {
       report_error("Expected 'else' in if expression");
+      return nullptr;
       return nullptr;
       return nullptr;
       return nullptr;

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -1065,22 +1065,26 @@ std::unique_ptr<XPathNode> XPathParser::parse_if_expr() {
 
    if (!match(XPathTokenType::LPAREN)) {
       report_error("Expected '(' after 'if'");
+      return nullptr;
    }
 
    auto condition = parse_expr();
 
    if (!match(XPathTokenType::RPAREN)) {
       report_error("Expected ')' after condition in if expression");
+      return nullptr;
    }
 
    if (!match(XPathTokenType::THEN)) {
       report_error("Expected 'then' in if expression");
+      return nullptr;
    }
 
    auto then_branch = parse_expr();
 
    if (!match(XPathTokenType::ELSE)) {
       report_error("Expected 'else' in if expression");
+      return nullptr;
    }
 
    auto else_branch = parse_expr();

--- a/src/xml/xpath/xpath_parser.h
+++ b/src/xml/xpath/xpath_parser.h
@@ -68,6 +68,8 @@ class XPathParser {
    std::unique_ptr<XPathNode> parse_union_expr();
    std::unique_ptr<XPathNode> parse_path_expr();
    std::unique_ptr<XPathNode> parse_filter_expr();
+   std::unique_ptr<XPathNode> parse_if_expr();
+   std::unique_ptr<XPathNode> parse_for_expr();
    std::unique_ptr<XPathNode> parse_location_path();
    std::unique_ptr<XPathNode> parse_absolute_location_path();
    std::unique_ptr<XPathNode> parse_relative_location_path();


### PR DESCRIPTION
## Summary
- add tokenizer and AST support for XPath if/then/else and simple for expressions
- extend the parser and evaluator to interpret conditional and for expressions with scoped variable bindings
- add Fluid tests demonstrating conditional branching and for-expression aggregation

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d71e831b24832ea7dcaf8ed9bee62d