### PR TITLE
Fix XPath GetKey expression evaluation

### DIFF
--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -2477,7 +2477,14 @@ XPathValue XPathEvaluator::evaluate_xpath_expression(std::string_view XPathExpr,
 
    // Evaluate the compiled AST and return the XPathValue directly
    expression_unsupported = false;
-   auto result = evaluate_expression(compiled.getAST(), CurrentPrefix);
+
+   const XPathNode *expression_node = compiled.getAST();
+   if (expression_node and (expression_node->type IS XPathNodeType::EXPRESSION)) {
+      if (expression_node->child_count() > 0) expression_node = expression_node->get_child(0);
+      else expression_node = nullptr;
+   }
+
+   auto result = evaluate_expression(expression_node, CurrentPrefix);
 
    if (expression_unsupported) {
       // Return empty string for unsupported expressions


### PR DESCRIPTION
## Summary
- unwrap EXPRESSION roots in XPathEvaluator::evaluate_xpath_expression so function results such as count() are returned

## Testing
- `ctest --build-config Release --test-dir build/agents -R xml_xpath_predicates --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68d7b0d7993c832e841df6e3ba7b4181