### PR TITLE
Fix XPath text extraction and exists() handling

### DIFF
--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -159,6 +159,7 @@ class XPathFunctionLibrary {
    static XPathValue function_true(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_false(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_lang(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_exists(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_number(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_sum(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_floor(const std::vector<XPathValue> &Args, const XPathContext &Context);


### PR DESCRIPTION
## Summary
- ensure XPath string conversions include descendant content and attribute values when needed
- implement and register the XPath exists() function for use with GetKey
- normalise string-returning helpers so empty results stay strings, fixing normalize-space edge cases

## Testing
- ctest --build-config Release --test-dir build/agents -R xml

------
https://chatgpt.com/codex/tasks/task_e_68d7ce7fb8cc832e9e595522126bc276