### PR TITLE
XPath Evaluation Improvements

### DIFF
--- a/src/xml/tests/test_advanced_features.fluid
+++ b/src/xml/tests/test_advanced_features.fluid
@@ -268,7 +268,7 @@ function testContentExists()
 
    -- Test element with content
    local contentExists = xml.getKey('exists(/root/withContent)')
-   assert(contentExists == "true", "Element with content should report content exists, got: " .. emptyExists)
+   assert(contentExists == "true", "Element with content should report content exists, got: " .. contentExists)
 
    -- Test element with only whitespace
    local whitespaceExists = xml.getKey('boolean(normalize-space(/root/whitespaceOnly))')

--- a/src/xml/tests/test_advanced_features.fluid
+++ b/src/xml/tests/test_advanced_features.fluid
@@ -255,24 +255,37 @@ function testRemoveXPathAttributes()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Test contentexists: getKey operation
+-- Test exists() function
 
-function testContentExists()
+function testExists()
    local xml = obj.new("xml", {
-      statement = '<root><empty/><withContent>Some text</withContent><whitespaceOnly>   \n\t  </whitespaceOnly></root>'
+      statement = '<root><empty attrib="value" blank=""/><withContent>Some text</withContent><whitespaceOnly>   \n\t  </whitespaceOnly></root>'
    })
 
-   -- Test empty element
    local emptyExists = xml.getKey('exists(/root/empty/text())')
-   assert(emptyExists == "false", "Empty element should report no content, got: " .. emptyExists)
+   assert(emptyExists == "false", "exists() on text() should report no content, got: " .. emptyExists)
 
-   -- Test element with content
-   local contentExists = xml.getKey('exists(/root/withContent)')
-   assert(contentExists == "true", "Element with content should report content exists, got: " .. contentExists)
+   local emptyExists = xml.getKey('exists(/root/empty)')
+   assert(emptyExists == "true", "Targeted empty element exists, got: " .. emptyExists)
+
+   local elementExists = xml.getKey('exists(/root/withContent)')
+   assert(elementExists == "true", "Element with content should report element exists, got: " .. elementExists)
+
+   local attribExists = xml.getKey('exists(/root/empty/@attrib)')
+   assert(attribExists == "true", "Targeted attrib element exists, got: " .. attribExists)
+
+   local attribExists = xml.getKey('exists(/root/empty/@blank)')
+   assert(attribExists == "true", "Targeted blank element exists, got: " .. attribExists)
+
+   local attribExists = xml.getKey('exists(/root/empty/@doesnotexist)')
+   assert(attribExists == "false", "Unexpected result for non-existant attribute, got: " .. attribExists)
+
+   local attribExists = xml.getKey('exists(string(/root/empty/@blank))')
+   assert(attribExists == "true", "Expected true because blank exists despite being empty, got: " .. attribExists)
 
    -- Test element with only whitespace
    local whitespaceExists = xml.getKey('boolean(normalize-space(/root/whitespaceOnly))')
-   assert(whitespaceExists == "false", "Whitespace-only should report no content, got: " .. emptyExists)
+   assert(whitespaceExists == "false", "Normalised whitespace should report no content, got: " .. whitespaceExists)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -282,7 +295,7 @@ return {
       'testParsingFlags', 'testWhitespaceHandling', 'testContentStripping', 'testHeaderStripping',
       'testWellFormedValidation', 'testEntityParsing', 'testNoEscapeMode', 'testSortingFlags',
       'testSerializationFlags', 'testContentExtraction', 'testCountMethods', 'testFilterMethod',
-      'testRemoveXPathAttributes', 'testContentExists'
+      'testRemoveXPathAttributes', 'testExists'
    },
    init = function(ScriptFolder)
       -- No global init needed for these tests

--- a/src/xml/tests/test_advanced_features.fluid
+++ b/src/xml/tests/test_advanced_features.fluid
@@ -184,7 +184,7 @@ function testContentExtraction()
    assert(string.find(buffer, "end"), "Should include direct text")
 
    -- Test deep content extraction via getKey
-   local deepContent = xml.getKey('content:/root')
+   local deepContent = xml.getKey('string(/root)')
    assert(string.find(deepContent, "emphasized"), "Deep extraction should include nested content")
    assert(string.find(deepContent, "strong"), "Deep extraction should include nested content")
 end
@@ -203,11 +203,11 @@ function testCountMethods()
    assert(methodCount == 5, "Should count all items: got " .. methodCount)
 
    -- Test count: getKey
-   local keyCount = tonumber(xml.getKey('count://item'))
+   local keyCount = tonumber(xml.getKey('count(//item)'))
    assert(keyCount == 5, "Should count all items: got " .. keyCount)
 
    -- Test specific path count
-   local sectionCount = tonumber(xml.getKey('count:/root/section[1]/item'))
+   local sectionCount = tonumber(xml.getKey('count(/root/section[1]/item)'))
    assert(sectionCount == 2, "Should count items in first section only, got " .. sectionCount)
 end
 
@@ -263,16 +263,16 @@ function testContentExists()
    })
 
    -- Test empty element
-   local emptyExists = xml.getKey('contentexists:/root/empty')
-   assert(emptyExists == "0", "Empty element should report no content")
+   local emptyExists = xml.getKey('exists(/root/empty/text())')
+   assert(emptyExists == "false", "Empty element should report no content, got: " .. emptyExists)
 
    -- Test element with content
-   local contentExists = xml.getKey('contentexists:/root/withContent')
-   assert(contentExists == "1", "Element with content should report content exists")
+   local contentExists = xml.getKey('exists(/root/withContent)')
+   assert(contentExists == "true", "Element with content should report content exists, got: " .. emptyExists)
 
    -- Test element with only whitespace
-   local whitespaceExists = xml.getKey('contentexists:/root/whitespaceOnly')
-   assert(whitespaceExists == "0", "Whitespace-only should report no content")
+   local whitespaceExists = xml.getKey('boolean(normalize-space(/root/whitespaceOnly))')
+   assert(whitespaceExists == "false", "Whitespace-only should report no content, got: " .. emptyExists)
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/xml/tests/test_xpath_advanced.fluid
+++ b/src/xml/tests/test_xpath_advanced.fluid
@@ -86,10 +86,10 @@ function testConditionalIfExpression()
       statement = '<root><item id="a">Alpha</item><item id="b">Beta</item></root>'
    })
 
-   local chosen = xml.getKey('xpath:if (/root/item[@id="a"]) then /root/item[@id="a"] else /root/item[@id="b"]')
+   local chosen = xml.getKey('if (/root/item[@id="a"]) then /root/item[@id="a"] else /root/item[@id="b"]')
    assert(chosen == 'Alpha', 'If expression should return Alpha branch when predicate succeeds, got ' .. nz(chosen, 'NIL'))
 
-   local fallback = xml.getKey('xpath:if (/root/item[@id="missing"]) then /root/item[@id="a"] else /root/item[@id="b"]')
+   local fallback = xml.getKey('if (/root/item[@id="missing"]) then /root/item[@id="a"] else /root/item[@id="b"]')
    assert(fallback == 'Beta', 'If expression should evaluate else branch when condition fails, got ' .. nz(fallback, 'NIL'))
 end
 

--- a/src/xml/tests/test_xpath_core.fluid
+++ b/src/xml/tests/test_xpath_core.fluid
@@ -245,7 +245,7 @@ function testContentExtraction()
    assert(string.find(immediateContent, "more content"), "Trailing content not extracted")
 
    -- Test deep content extraction
-   local deepContent = xml.getKey('string(/root/section/)')
+   local deepContent = xml.getKey('string(/root/section)')
    assert(string.find(deepContent, "emphasized"), "Deep content not extracted, got: " .. deepContent)
 end
 

--- a/src/xml/tests/test_xpath_core.fluid
+++ b/src/xml/tests/test_xpath_core.fluid
@@ -200,11 +200,11 @@ function testCountOperations()
    })
 
    -- Count all items
-   local totalItems = tonumber(xml.getKey('count://item'))
+   local totalItems = tonumber(xml.getKey('count(//item)'))
    assert(totalItems == 4, "Expected 4 total items, got " .. totalItems)
 
    -- Count items in first section
-   local firstSectionItems = tonumber(xml.getKey('count:/root/section[1]/item'))
+   local firstSectionItems = tonumber(xml.getKey('count(/root/section[1]/item)'))
    assert(firstSectionItems == 3, "Expected 3 items in first section, got " .. firstSectionItems)
 end
 
@@ -245,12 +245,12 @@ function testContentExtraction()
    assert(string.find(immediateContent, "more content"), "Trailing content not extracted")
 
    -- Test deep content extraction
-   local deepContent = xml.getKey('content:/root/section')
-   assert(string.find(deepContent, "emphasized"), "Deep content not extracted")
+   local deepContent = xml.getKey('string(/root/section/)')
+   assert(string.find(deepContent, "emphasized"), "Deep content not extracted, got: " .. deepContent)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Test extract operations (XML serialization)
+-- Test serialisation operations
 
 function testExtractOperations()
    local xml = obj.new("xml", {
@@ -258,9 +258,11 @@ function testExtractOperations()
    })
 
    -- Extract XML for specific element
-   local extractedXML = xml.getKey('extract:/root/section/item')
-   assert(string.find(extractedXML, 'id="1"'), "Extracted XML is missing attributes: " .. nz(extractedXML,'NIL'))
-   assert(string.find(extractedXML, "Content"), "Extracted XML is missing content" .. nz(extractedXML,'NIL'))
+   local err, id = xml.mtFindTag('/root/section/item')
+   local err, result = xml.mtSerialise(id, false)
+
+   assert(string.find(result, 'id="1"'), "Extracted XML is missing attributes: " .. nz(result,'NIL'))
+   assert(string.find(result, "Content"), "Extracted XML is missing content" .. nz(result,'NIL'))
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/xml/tests/test_xpath_predicates.fluid
+++ b/src/xml/tests/test_xpath_predicates.fluid
@@ -492,11 +492,11 @@ function testFunctionLibrary()
 
    -- Test that basic XPath functionality continues to work with infrastructure
 
-   local bookContent = xml.getKey('content:/library/books/book[@id="2"]')
+   local bookContent = xml.getKey('/library/books/book[@id="2"]/text()')
    assert(bookContent, "Book should have content")
 
    -- Test content extraction (important for function library string operations)
-   local authorContent = xml.getKey('content:/library/authors/author[@name="Donald Knuth"]')
+   local authorContent = xml.getKey('/library/authors/author[@name="Donald Knuth"]/text()')
    assert(authorContent, "Author should have content")
 
    -- Test navigation to container elements (important for node-set functions)
@@ -732,18 +732,16 @@ function testXPathFullEvaluation()
       statement = '<root><item>A</item><item>B</item><item>C</item><section><item>D</item></section></root>'
    })
 
-   local count_regular = xml.getKey('count:/root/item')
-
-   local count = xml.getKey('xpath:count(/root/item)')
+   local count = xml.getKey('count(/root/item)')
    assert(count == "3", "Expected count of 3 items, got " .. nz(count, "NIL"))
 
-   local total_count = xml.getKey('xpath:count(/root/*)')
+   local total_count = xml.getKey('count(/root/*)')
    assert(total_count == "4", "Expected count of 4 elements, got " .. nz(total_count, "NIL"))
 
-   local if_result = xml.getKey('xpath:if (/root/item[1]) then /root/item[1] else /root/item[2]')
+   local if_result = xml.getKey('if (/root/item[1]) then /root/item[1] else /root/item[2]')
    assert(if_result == "A", "Expected if result 'A', got " .. nz(if_result, "NIL"))
 
-   local length = xml.getKey('xpath:string-length(/root/item[1])')
+   local length = xml.getKey('string-length(/root/item[1])')
    assert(length == "1", "Expected string length of 1, got " .. nz(length, "NIL"))
 end
 

--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -2477,7 +2477,14 @@ XPathValue XPathEvaluator::evaluate_xpath_expression(std::string_view XPathExpr,
 
    // Evaluate the compiled AST and return the XPathValue directly
    expression_unsupported = false;
-   auto result = evaluate_expression(compiled.getAST(), CurrentPrefix);
+
+   const XPathNode *expression_node = compiled.getAST();
+   if (expression_node and (expression_node->type IS XPathNodeType::EXPRESSION)) {
+      if (expression_node->child_count() > 0) expression_node = expression_node->get_child(0);
+      else expression_node = nullptr;
+   }
+
+   auto result = evaluate_expression(expression_node, CurrentPrefix);
 
    if (expression_unsupported) {
       // Return empty string for unsupported expressions

--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -70,7 +70,7 @@ class XPathEvaluator {
    ERR find_tag(const CompiledXPath &, uint32_t);
 
    // Full XPath expression evaluation returning computed values
-   XPathValue evaluate_xpath_expression(std::string_view XPathExpr, uint32_t CurrentPrefix = 0);
+   ERR evaluate_xpath_expression(const CompiledXPath &, XPathValue &, uint32_t CurrentPrefix = 0);
 
    // Context management for AST evaluation
    void push_context(XMLTag *Node, size_t Position = 1, size_t Size = 1, const XMLAttrib *Attribute = nullptr);

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -159,6 +159,7 @@ class XPathFunctionLibrary {
    static XPathValue function_true(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_false(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_lang(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_exists(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_number(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_sum(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_floor(const std::vector<XPathValue> &Args, const XPathContext &Context);


### PR DESCRIPTION
This pull request modernizes and simplifies the XML querying infrastructure by fully transitioning from legacy key-value prefixes (like `count:`, `exists:`, `content:`, etc.) to direct XPath 2.0 function calls. It refactors both the C++ backend and the test suite to use standard XPath expressions, removes deprecated code paths, and introduces a unified evaluation interface. These changes improve maintainability, clarity, and consistency in XML data access.

**Core API and Backend Refactoring:**

* Deprecated legacy key prefixes such as `count:`, `exists:`, `contentexists:`, and extraction-related prefixes in favor of direct XPath 2.0 function calls (e.g., `count(...)`, `exists(...)`, `string(...)`). The backend now logs errors and returns syntax errors for old prefixes, guiding users to use XPath functions instead. 
* Introduced new `evaluate` methods in `extXML` to compile and evaluate XPath queries, replacing the previous prefix-based dispatch and enabling direct evaluation of any XPath expression. 
* Removed the old `find_tag` entry point from the XPath evaluator, ensuring all queries now use the new evaluation path.

**Test Suite Modernization:**

* Updated all tests to use standard XPath 2.0 function calls in place of legacy prefixes, ensuring coverage and correctness of the new querying approach.

**XPath Engine Improvements:**

* Enhanced attribute axis evaluation in the XPath engine to correctly support predicates on attributes, improving standards compliance and query flexibility.

These changes collectively make XML querying more robust, future-proof, and aligned with XPath standards.