### PR TITLE
Implement XPath variable guard and faster context map

### DIFF
--- a/src/xml/xpath/xpath_evaluator.cpp
+++ b/src/xml/xpath/xpath_evaluator.cpp
@@ -2238,7 +2238,6 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
             return false;
          }
 
-         std::optional<VariableBindingGuard> binding_guard;
          const std::string variable_name = binding.name;
 
          auto sequence_value = evaluate_expression(binding.sequence, CurrentPrefix);
@@ -2277,8 +2276,7 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
             bound_value.node_set_string_values.push_back(item_string);
             bound_value.node_set_string_override = item_string;
 
-            if (!binding_guard.has_value()) binding_guard.emplace(context, variable_name, std::move(bound_value));
-            else context.variables[variable_name] = std::move(bound_value);
+            VariableBindingGuard iteration_guard(context, variable_name, std::move(bound_value));
 
             push_context(item_node, index + 1, sequence_size, item_attribute);
             bool iteration_ok = evaluate_bindings(binding_index + 1);
@@ -2367,7 +2365,6 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
             return false;
          }
 
-         std::optional<VariableBindingGuard> binding_guard;
          const std::string variable_name = binding.name;
 
          auto sequence_value = evaluate_expression(binding.sequence, CurrentPrefix);
@@ -2406,8 +2403,7 @@ XPathValue XPathEvaluator::evaluate_expression(const XPathNode *ExprNode, uint32
             bound_value.node_set_string_values.push_back(item_string);
             bound_value.node_set_string_override = item_string;
 
-            if (!binding_guard.has_value()) binding_guard.emplace(context, variable_name, std::move(bound_value));
-            else context.variables[variable_name] = std::move(bound_value);
+            VariableBindingGuard iteration_guard(context, variable_name, std::move(bound_value));
 
             push_context(item_node, index + 1, sequence_size, item_attribute);
             bool branch_result = evaluate_binding(binding_index + 1);

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -119,14 +119,14 @@ class VariableBindingGuard
    bool had_previous_value = false;
 
    public:
-   VariableBindingGuard(XPathContext &Context, const std::string &Name, XPathValue Value)
-      : context(Context), variable_name(Name)
+   VariableBindingGuard(XPathContext &Context, std::string Name, XPathValue Value)
+      : context(Context), variable_name(std::move(Name))
    {
-      auto existing = context.variables.find(Name);
+      auto existing = context.variables.find(variable_name);
       had_previous_value = (existing != context.variables.end());
       if (had_previous_value) previous_value = existing->second;
 
-      context.variables[Name] = std::move(Value);
+      context.variables[variable_name] = std::move(Value);
    }
 
    ~VariableBindingGuard()


### PR DESCRIPTION
## Summary
- replace the XPath evaluation context's std::map with an ankerl::unordered_dense::map for faster lookups
- add a VariableBindingGuard RAII helper to centralise variable scope restoration
- refactor FOR and quantified expression evaluation to rely on the guard instead of manual save/restore blocks

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d82cdc06f4832e850e8c4cf2c360e2