### PR TITLE
Add XPath let expression parsing and evaluation

### DIFF
--- a/src/xml/xpath/xpath_ast.h
+++ b/src/xml/xpath/xpath_ast.h
@@ -61,6 +61,7 @@ enum class XPathTokenType {
    THEN,              // then
    ELSE,              // else
    FOR,               // for
+   LET,               // let
    IN,                // in
    RETURN,            // return
    SOME,              // some
@@ -80,6 +81,7 @@ enum class XPathTokenType {
 
    // Variables and functions
    DOLLAR,            // $
+   ASSIGN,            // :=
 
    // Special tokens
    END_OF_INPUT,
@@ -125,6 +127,8 @@ enum class XPathNodeType {
    CONDITIONAL,
    FOR_EXPRESSION,
    FOR_BINDING,
+   LET_EXPRESSION,
+   LET_BINDING,
    QUANTIFIED_EXPRESSION,
    QUANTIFIED_BINDING,
    FUNCTION_CALL,

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -527,8 +527,6 @@ bool XPathParser::check_identifier_keyword(std::string_view Keyword) const {
       if (token.type IS XPathTokenType::EXCEPT) return true;
    }
 
-   if (token.value IS Keyword) return true;
-
    return (token.type IS XPathTokenType::IDENTIFIER) and (token.value IS Keyword);
 }
 

--- a/src/xml/xpath/xpath_parser.cpp
+++ b/src/xml/xpath/xpath_parser.cpp
@@ -976,8 +976,7 @@ std::unique_ptr<XPathNode> XPathParser::parse_let_expr() {
       binding_node->add_child(std::move(binding_expr));
       let_node->add_child(std::move(binding_node));
 
-      if (match(XPathTokenType::COMMA)) parsing_bindings = true;
-      else parsing_bindings = false;
+      parsing_bindings = match(XPathTokenType::COMMA);
    }
 
    XPathToken return_token(XPathTokenType::UNKNOWN, std::string_view());

--- a/src/xml/xpath/xpath_parser.h
+++ b/src/xml/xpath/xpath_parser.h
@@ -58,6 +58,8 @@ class XPathParser {
 
    // Grammar rule methods (XPath 1.0 grammar)
    std::unique_ptr<XPathNode> parse_expr();
+   std::unique_ptr<XPathNode> parse_flwor_expr();
+   std::unique_ptr<XPathNode> parse_let_expr();
    std::unique_ptr<XPathNode> parse_or_expr();
    std::unique_ptr<XPathNode> parse_and_expr();
    std::unique_ptr<XPathNode> parse_equality_expr();


### PR DESCRIPTION
## Summary
- add LET token, ASSIGN operator, and AST node types for let expressions
- extend the XPath parser to recognise let clauses via a shared FLWOR entry point
- evaluate let expressions by binding variables with guards before returning the result

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d8376911dc832ea431b20e8578bb0b