### PR TITLE
Add phase 4 XPath diagnostics and tests

### DIFF
--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -22,6 +22,7 @@ flute_test (${MOD}_xpath_core "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_core
 flute_test (${MOD}_xpath_predicates "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_predicates.fluid")
 flute_test (${MOD}_xpath_axes "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_axes.fluid")
 flute_test (${MOD}_xpath_advanced "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_advanced.fluid")
+flute_test (${MOD}_xpath_flwor "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_flwor.fluid")
 flute_test (${MOD}_parsing "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xml_parsing.fluid")
 flute_test (${MOD}_namespaces "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_namespaces.fluid")
 flute_test (${MOD}_variables "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_setvariable.fluid")

--- a/src/xml/tests/test_xpath_flwor.fluid
+++ b/src/xml/tests/test_xpath_flwor.fluid
@@ -1,0 +1,113 @@
+-- Phase 4 FLWOR and LET stabilisation tests
+
+   include 'xml'
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Basic LET expressions should evaluate arithmetic results
+
+function testLetSimpleArithmetic()
+   local xml = obj.new("xml", { statement = '<root/>' })
+   local result = tonumber(xml.getKey('let $price := 10.99 return $price * 1.1'))
+   assert(result and math.abs(result - 12.089) < 0.0001,
+      'Let expression should scale numeric values, got ' .. tostring(result))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Multiple bindings should be available inside the return clause
+
+function testLetMultipleBindings()
+   local xml = obj.new("xml", { statement = '<root/>' })
+   local result = tonumber(xml.getKey('let $a := 5, $b := 10 return $a + $b'))
+   assert(result and math.abs(result - 15.0) < 0.0001,
+      'Let expression should expose all bound variables, got ' .. tostring(result))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- LET expressions can combine node lookups with arithmetic
+
+function testLetDocumentComputation()
+   local xml = obj.new("xml", {
+      statement = '<catalog>' ..
+                  '<book id="bk-1" price="25"/>' ..
+                  '<book id="bk-2" price="45"/>' ..
+                  '</catalog>'
+   })
+
+   local result = tonumber(xml.getKey('let $tax := 0.08 return number(/catalog/book[@price > 20][1]/@price) * (1 + $tax)'))
+   assert(result and math.abs(result - 27.0) < 0.0001,
+      'Let expression should compute taxed pricing, got ' .. tostring(result))
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Invalid LET syntax should report descriptive parser errors
+
+function testLetSyntaxErrors()
+   local xml = obj.new("xml", { statement = '<root><value/></root>' })
+
+   local err = xml.mtFindTag('let $a return $a')
+   assert(err == ERR_Syntax, 'Missing assignment should be a syntax error, got ' .. mSys.GetErrorMsg(err))
+   local message = nz(xml.ErrorMsg, '')
+   assert(string.find(message, "Expected ':=' in let binding", 1, true),
+      'Error message should reference missing :=, got ' .. message)
+
+   local err2 = xml.mtFindTag('let $a := return 5')
+   assert(err2 == ERR_Syntax, 'Missing expression should be a syntax error, got ' .. mSys.GetErrorMsg(err2))
+   local message2 = nz(xml.ErrorMsg, '')
+   assert(string.find(message2, "Expected expression after ':=' in let binding", 1, true),
+      'Error message should reference missing binding expression, got ' .. message2)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- FLWOR return expressions that yield scalars should produce actionable diagnostics
+
+function testFlworNonNodeReturnError()
+   local xml = obj.new("xml", {
+      statement = '<library>' ..
+                  '<book id="a" genre="fiction" price="39"/>' ..
+                  '<book id="b" genre="reference" price="55"/>' ..
+                  '</library>'
+   })
+
+   local err = xml.mtFindTag('for $book in /library/book let $discounted := number($book/@price) * 0.9 return $discounted')
+   assert(err != ERR_Okay, 'Numeric FLWOR return should be rejected')
+   local message = nz(xml.ErrorMsg, '')
+   assert(string.find(message, 'return expressions must yield node-sets', 1, true),
+      'FLWOR error message should describe node-set requirement, got ' .. message)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Repeated FLWOR evaluations should remain stable and performant
+
+function testFlworRepeatedEvaluationConsistency()
+   local xml = obj.new("xml", {
+      statement = '<library>' ..
+                  '<book id="a" genre="fiction"/>' ..
+                  '<book id="b" genre="reference"/>' ..
+                  '<book id="c" genre="fiction"/>' ..
+                  '</library>'
+   })
+
+   for iteration = 1, 25 do
+      local collected = {}
+      local err = xml.mtFindTag('for $book in /library/book let $genre := $book/@genre return $book[$genre = "fiction"]',
+         function(XML, TagID)
+            local errAttr, idValue = xml.mtGetAttrib(TagID, 'id')
+            assert(errAttr == ERR_Okay,
+               'Iteration ' .. iteration .. ' should resolve id attribute: ' .. mSys.GetErrorMsg(errAttr))
+            table.insert(collected, idValue)
+         end)
+
+      assert(err == ERR_Okay, 'Iteration ' .. iteration .. ' should evaluate successfully: ' .. mSys.GetErrorMsg(err))
+      table.sort(collected)
+      assert(#collected == 2 and collected[1] == 'a' and collected[2] == 'c',
+         'Iteration ' .. iteration .. ' should yield consistent fiction ids, got ' .. table.concat(collected, ','))
+   end
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+return {
+   tests = {
+      'testLetSimpleArithmetic', 'testLetMultipleBindings', 'testLetDocumentComputation',
+      'testLetSyntaxErrors', 'testFlworNonNodeReturnError', 'testFlworRepeatedEvaluationConsistency'
+   }
+}

--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -5,6 +5,8 @@
 
 #include "xpath_arena.h"
 
+#include <string_view>
+
 struct XMLAttrib;
 
 class XPathEvaluator {
@@ -51,6 +53,8 @@ class XPathEvaluator {
    ERR evaluate_union(const XPathNode *Node, uint32_t CurrentPrefix);
 
    std::string build_ast_signature(const XPathNode *Node) const;
+
+   void record_error(std::string_view Message, bool Force = false);
 
    public:
    explicit XPathEvaluator(extXML *XML) : xml(XML), axis_evaluator(XML, arena) {


### PR DESCRIPTION
## Summary
- extend the XPath evaluator with a reusable `record_error` helper and richer LET/FLWOR diagnostics that populate `ErrorMsg`
- register a dedicated phase 4 FLWOR/LET flute suite in the XML module build
- cover basic let arithmetic, syntax failures, numeric FLWOR errors, and repeated evaluation in new tests

## Testing
- cmake --build build/agents --config Release --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d841e7d280832ea26ab3cf5da384e2