### PR TITLE
Implement DOCTYPE parsing and entity accessors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ Key build options (use with `-D` flag):
 
 ### Development in the Cloud (Temporary Sessions)
 
-Always enable the fast build configuration `-DCMAKE_BUILD_TYPE=FastBuild` when in a cloud session.
+Always enable the fast build configuration `-DCMAKE_BUILD_TYPE=FastBuild` when in a temporary session.
 
-If you are running in a cloud session then disabling unnecessary modules like Audio and Graphics features (if they are not being worked on) will speed up the build.  You should include the following with your CMake build configuration:
+Disabling unnecessary modules like Audio and Graphics features (if they are not being worked on) will speed up the build.  You should include the following with your CMake build configuration:
 - `-DDISABLE_AUDIO=ON -DDISABLE_X11=ON -DDISABLE_DISPLAY=ON -DDISABLE_FONT=ON`
 
 Performing the build and install process is essential if intending to run `parasol` for Fluid scripts and Flute tests.

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -15,8 +15,8 @@
     <category>Data</category>
     <copyright>Paul Manias © 2001-2025</copyright>
     <description>
-<p>The XML class is designed to provide robust functionality for creating, parsing and maintaining XML data structures. It supports both well-formed and loosely structured XML documents, offering flexible parsing behaviours to accommodate various XML formats.  The class includes comprehensive support for XPath queries, content manipulation and document validation.</p>
-<p>The class has been designed in such a way as to accommodate other structured data formats such as JSON and YAML.  In this way, the class not only provides XML support but also serves as Parasol's general-purpose structured data handler.  It also makes it trivial to convert between different structured data formats, and benefit from the cross-application use of features, such as applying XPath queries on data originating from YAML.</p>
+<p>The XML class is designed to provide robust functionality for creating, parsing and maintaining XML data structures. It supports both well-formed and loosely structured XML documents, offering flexible parsing behaviours to accommodate various XML formats.  The class includes comprehensive support for XPath 2.0 queries, content manipulation and document validation.</p>
+<p>The class has been designed in such a way as to accommodate other structured data formats such as JSON and YAML.  In this way, the class not only provides XML support but also serves as Parasol's general-purpose structured data handler.  It also makes it trivial to convert between different structured data formats, and benefit from the cross-application use of features, such as applying XPath 2.0 queries on data originating from YAML.</p>
 <header>Data Loading and Parsing</header>
 <p>XML documents can be loaded into an XML object through multiple mechanisms:</p>
 <p>The <fl>Path</fl> field allows loading from file system sources, with automatic parsing upon initialisation.  The class supports <function module="Core">LoadFile</function> caching for frequently accessed files, improving performance for repeated operations.</p>
@@ -247,6 +247,24 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     </method>
 
     <method>
+      <name>GetEntity</name>
+      <comment>Retrieves the value of a parsed entity declaration.</comment>
+      <prototype>ERR xml::GetEntity(OBJECTPTR Object, CSTRING Name, CSTRING * Value)</prototype>
+      <input>
+        <param type="CSTRING" name="Name">The name of the entity to retrieve.  This must correspond to a parsed entity declaration.</param>
+        <param type="CSTRING *" name="Value">Receives the resolved entity value on success.  The returned pointer remains valid while the XML object exists.</param>
+      </input>
+      <description>
+<p>This method returns the expanded value associated with a general entity parsed from the document's DOCTYPE declaration. Entity names are case-sensitive and must match exactly as declared.</p>
+      </description>
+      <result>
+        <error code="Okay">The entity was found and its value returned.</error>
+        <error code="Search">No matching entity could be found for the specified name.</error>
+        <error code="NullArgs">Either the Name or Value parameter was NULL.</error>
+      </result>
+    </method>
+
+    <method>
       <name>GetNamespaceURI</name>
       <comment>Retrieve the namespace URI for a given namespace UID.</comment>
       <prototype>ERR xml::GetNamespaceURI(OBJECTPTR Object, UINT NamespaceID, CSTRING * Result)</prototype>
@@ -261,6 +279,24 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
         <error code="Okay">The namespace URI was successfully retrieved.</error>
         <error code="Search">No namespace found for the specified UID.</error>
         <error code="NullArgs">Required arguments were not specified correctly.</error>
+      </result>
+    </method>
+
+    <method>
+      <name>GetNotation</name>
+      <comment>Retrieves information about a parsed notation declaration.</comment>
+      <prototype>ERR xml::GetNotation(OBJECTPTR Object, CSTRING Name, CSTRING * Value)</prototype>
+      <input>
+        <param type="CSTRING" name="Name">The notation name to look up.</param>
+        <param type="CSTRING *" name="Value">Receives the notation descriptor on success.</param>
+      </input>
+      <description>
+<p>Returns the system or public identifier captured for a notation declaration inside the document type definition.  If both public and system identifiers were provided they are returned as a single string separated by a single space.</p>
+      </description>
+      <result>
+        <error code="Okay">The notation was found and its descriptor returned.</error>
+        <error code="Search">No matching notation could be found for the specified name.</error>
+        <error code="NullArgs">Either the Name or Value parameter was NULL.</error>
       </result>
     </method>
 
@@ -568,6 +604,19 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
 
   <fields>
     <field>
+      <name>DocType</name>
+      <comment>Root element name from DOCTYPE declaration</comment>
+      <access>-/-</access>
+      <type>STRING</type>
+    </field>
+
+    <field>
+      <name>DocumentType</name>
+      <access read="R">Read</access>
+      <type>STRING</type>
+    </field>
+
+    <field>
       <name>ErrorMsg</name>
       <comment>A textual description of the last parse error.</comment>
       <access read="G">Get</access>
@@ -606,6 +655,13 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
 <p>XML documents can be loaded from the file system by specifying a file path in this field.  If set post-initialisation, all currently loaded data will be cleared and the file will be parsed automatically.</p>
 <p>The XML class supports <function module="Core">LoadFile</function>, so an XML file can be pre-cached by the program if it is frequently used during a program's life cycle.</p>
       </description>
+    </field>
+
+    <field>
+      <name>PublicID</name>
+      <comment>Public identifier for external DTD</comment>
+      <access read="R">Read</access>
+      <type>STRING</type>
     </field>
 
     <field>
@@ -650,6 +706,13 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
 <p>Be aware that setting this field with an invalid statement will result in an empty XML object.</p>
 <p>Reading the Statement field will return a serialised string of XML data.  By default all tags will be included in the statement unless a predefined starting position is set by the <fl>Start</fl> field.  The string result is an allocation that must be freed.</p>
       </description>
+    </field>
+
+    <field>
+      <name>SystemID</name>
+      <comment>System identifier for external DTD</comment>
+      <access read="R">Read</access>
+      <type>STRING</type>
     </field>
 
     <field>

--- a/include/parasol/modules/xml.h
+++ b/include/parasol/modules/xml.h
@@ -145,12 +145,6 @@ typedef struct XMLTag {
    }
 } XMLTAG;
 
-typedef struct DTDInfo {
-   std::string DocumentType;
-   std::string PublicID;
-   std::string SystemID;
-} DTDINFO;
-
 // XML class definition
 
 #define VER_XML (1.000000)
@@ -180,7 +174,6 @@ struct ResolvePrefix { CSTRING Prefix; int TagID; uint32_t Result; static const 
 struct SetVariable { CSTRING Key; CSTRING Value; static const AC id = AC(-23); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetEntity { CSTRING Name; CSTRING Value; static const AC id = AC(-24); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetNotation { CSTRING Name; CSTRING Value; static const AC id = AC(-25); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct GetDTDInfo { struct DTDInfo * Info; static const AC id = AC(-26); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -191,16 +184,16 @@ class objXML : public Object {
 
    using create = pf::Create<objXML>;
 
-   STRING    Path;         // Set this field if the XML document originates from a file source.
-   STRING    DocumentType; // Root element name from DOCTYPE declaration
-   STRING    PublicID;     // Public identifier for external DTD
-   STRING    SystemID;     // System identifier for external DTD
-   OBJECTPTR Source;       // Set this field if the XML data is to be sourced from another object.
-   XMF       Flags;        // Controls XML parsing behaviour and processing options.
-   int       Start;        // Set a starting cursor to affect the starting point for some XML operations.
-   int       Modified;     // A timestamp of when the XML data was last modified.
-   ERR       ParseError;   // Private
-   int       LineNo;       // Private
+   STRING    Path;    // Set this field if the XML document originates from a file source.
+   STRING    DocType; // Root element name from DOCTYPE declaration
+   STRING    PublicID; // Public identifier for external DTD
+   STRING    SystemID; // System identifier for external DTD
+   OBJECTPTR Source;  // Set this field if the XML data is to be sourced from another object.
+   XMF       Flags;   // Controls XML parsing behaviour and processing options.
+   int       Start;   // Set a starting cursor to affect the starting point for some XML operations.
+   int       Modified; // A timestamp of when the XML data was last modified.
+   ERR       ParseError; // Private
+   int       LineNo;  // Private
    public:
    typedef pf::vector<XMLTag> TAGS;
    typedef pf::vector<XMLTag>::iterator CURSOR;
@@ -354,28 +347,24 @@ class objXML : public Object {
       struct xml::SetVariable args = { Key, Value };
       return(Action(AC(-23), this, &args));
    }
-   inline ERR getEntity(CSTRING Name, CSTRING * Result) noexcept {
+   inline ERR getEntity(CSTRING Name, CSTRING * Value) noexcept {
       struct xml::GetEntity args = { Name, (CSTRING)0 };
       ERR error = Action(AC(-24), this, &args);
-      if (Result) *Result = args.Value;
+      if (Value) *Value = args.Value;
       return(error);
    }
-   inline ERR getNotation(CSTRING Name, CSTRING * Result) noexcept {
+   inline ERR getNotation(CSTRING Name, CSTRING * Value) noexcept {
       struct xml::GetNotation args = { Name, (CSTRING)0 };
       ERR error = Action(AC(-25), this, &args);
-      if (Result) *Result = args.Value;
+      if (Value) *Value = args.Value;
       return(error);
-   }
-   inline ERR getDTDInfo(struct DTDInfo * Info) noexcept {
-      struct xml::GetDTDInfo args = { Info };
-      return(Action(AC(-26), this, &args));
    }
 
    // Customised field setting
 
    template <class T> inline ERR setPath(T && Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[10];
+      auto field = &this->Class->Dictionary[12];
       return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
    }
 
@@ -397,13 +386,13 @@ class objXML : public Object {
 
    inline ERR setReadOnly(const int Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[15];
+      auto field = &this->Class->Dictionary[18];
       return field->WriteValue(target, field, FD_INT, &Value, 1);
    }
 
    template <class T> inline ERR setStatement(T && Value) noexcept {
       auto target = this;
-      auto field = &this->Class->Dictionary[12];
+      auto field = &this->Class->Dictionary[14];
       return field->WriteValue(target, field, 0x08800320, to_cstring(Value), 1);
    }
 

--- a/include/parasol/modules/xml.h
+++ b/include/parasol/modules/xml.h
@@ -145,6 +145,12 @@ typedef struct XMLTag {
    }
 } XMLTAG;
 
+typedef struct DTDInfo {
+   std::string DocumentType;
+   std::string PublicID;
+   std::string SystemID;
+} DTDINFO;
+
 // XML class definition
 
 #define VER_XML (1.000000)
@@ -172,6 +178,9 @@ struct GetNamespaceURI { uint32_t NamespaceID; CSTRING Result; static const AC i
 struct SetTagNamespace { int TagID; int NamespaceID; static const AC id = AC(-21); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct ResolvePrefix { CSTRING Prefix; int TagID; uint32_t Result; static const AC id = AC(-22); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct SetVariable { CSTRING Key; CSTRING Value; static const AC id = AC(-23); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct GetEntity { CSTRING Name; CSTRING Value; static const AC id = AC(-24); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct GetNotation { CSTRING Name; CSTRING Value; static const AC id = AC(-25); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct GetDTDInfo { struct DTDInfo * Info; static const AC id = AC(-26); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -344,6 +353,22 @@ class objXML : public Object {
    inline ERR setVariable(CSTRING Key, CSTRING Value) noexcept {
       struct xml::SetVariable args = { Key, Value };
       return(Action(AC(-23), this, &args));
+   }
+   inline ERR getEntity(CSTRING Name, CSTRING * Result) noexcept {
+      struct xml::GetEntity args = { Name, (CSTRING)0 };
+      ERR error = Action(AC(-24), this, &args);
+      if (Result) *Result = args.Value;
+      return(error);
+   }
+   inline ERR getNotation(CSTRING Name, CSTRING * Result) noexcept {
+      struct xml::GetNotation args = { Name, (CSTRING)0 };
+      ERR error = Action(AC(-25), this, &args);
+      if (Result) *Result = args.Value;
+      return(error);
+   }
+   inline ERR getDTDInfo(struct DTDInfo * Info) noexcept {
+      struct xml::GetDTDInfo args = { Info };
+      return(Action(AC(-26), this, &args));
    }
 
    // Customised field setting

--- a/src/xml/tests/benchmark.fluid
+++ b/src/xml/tests/benchmark.fluid
@@ -174,7 +174,7 @@ function benchmarkAttributeScanning()
 end
 
 function benchmarkConditionalCounting()
-   local totalProducts = tonumber(glXML.getKey('count://product'))
+   local totalProducts = tonumber(glXML.getKey('count(//product)'))
    assert(totalProducts > 0, "Conditional counting failed")
 end
 
@@ -205,7 +205,7 @@ end
 -- Content and Structure Benchmarks
 
 function benchmarkContentExtraction()
-   local content = glXML.getKey('content://product[@id="prod-1"]')
+   local content = glXML.getKey('string(//product[@id="prod-1"])')
    assert(content, "Content extraction failed")
 end
 
@@ -261,7 +261,7 @@ end
 
    print('Benchmark data loaded successfully')
    print('Document root: ' .. nz(glXML.getKey('/catalog/@name'), 'Unknown'))
-   print('Total products: ' .. nz(glXML.getKey('count://product'), '0'))
+   print('Total products: ' .. nz(glXML.getKey('count(//product)'), '0'))
    print('')
 
    print('=== 1. Basic Navigation Tests ===')

--- a/src/xml/tests/test_advanced_features.fluid
+++ b/src/xml/tests/test_advanced_features.fluid
@@ -107,7 +107,7 @@ function testEntityParsing()
       flags = XMF_PARSE_ENTITY
    })
 
-   assert(xml.documentType == 'root', 'Document type field should be populated')
+   assert(xml.docType == 'root', 'Document type field should be populated')
    assert(xml.publicID == '-//Example//DTD Example//EN', 'Public identifier should match declaration')
    assert(xml.systemID == 'http://example.com/example.dtd', 'System identifier should match declaration')
 
@@ -116,13 +116,6 @@ function testEntityParsing()
 
    local notationErr, notationValue = xml.mtGetNotation('icon')
    assert(notationErr == ERR_Okay and notationValue == 'viewer', 'Notation lookup should return the system identifier')
-
-   local info = struct.new('DTDInfo')
-   local infoErr = xml.mtGetDTDInfo(info)
-   assert(infoErr == ERR_Okay, 'GetDTDInfo should succeed')
-   assert(info.documentType == 'root', 'DTDInfo should copy the document type name')
-   assert(info.publicID == xml.publicID, 'DTDInfo should copy the public identifier')
-   assert(info.systemID == xml.systemID, 'DTDInfo should copy the system identifier')
 
    local resolved = xml.getKey('string(/root)')
    assert(resolved == 'value and more', 'Entity references should be expanded in content')
@@ -168,25 +161,25 @@ function testSortingFlags()
 end
 
 -----------------------------------------------------------------------------------------------------------------------
--- Test serialization flags
+-- Test serialisation flags
 
-function testSerializationFlags()
+function testSerialisationFlags()
    local xml = obj.new("xml", {
       statement = '<root><child attr="value">Content</child></root>'
    })
 
-   -- Test readable serialization
+   -- Test readable serialisation
    local err, readable = xml.mtSerialise(0, bit.bor(XMF_READABLE, XMF_INCLUDE_SIBLINGS))
-   assert(err == ERR_Okay, "Readable serialization should succeed")
+   assert(err == ERR_Okay, "Readable serialisation should succeed")
    assert(string.find(readable, '\n'), "Readable format should include newlines")
 
-   -- Test compact serialization
+   -- Test compact serialisation
    local err, compact = xml.mtSerialise(0, XMF_INCLUDE_SIBLINGS)
-   assert(err == ERR_Okay, "Compact serialization should succeed")
+   assert(err == ERR_Okay, "Compact serialisation should succeed")
 
-   -- Test omit tags serialization
+   -- Test omit tags serialisation
    local err, content = xml.mtSerialise(0, bit.bor(XMF_OMIT_TAGS, XMF_INCLUDE_SIBLINGS))
-   assert(err == ERR_Okay, "Content-only serialization should succeed")
+   assert(err == ERR_Okay, "Content-only serialisation should succeed")
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -318,7 +311,7 @@ return {
    tests = {
       'testParsingFlags', 'testWhitespaceHandling', 'testContentStripping', 'testHeaderStripping',
       'testWellFormedValidation', 'testEntityParsing', 'testNoEscapeMode', 'testSortingFlags',
-      'testSerializationFlags', 'testContentExtraction', 'testCountMethods', 'testFilterMethod',
+      'testSerialisationFlags', 'testContentExtraction', 'testCountMethods', 'testFilterMethod',
       'testRemoveXPathAttributes', 'testExists'
    },
    init = function(ScriptFolder)

--- a/src/xml/tests/test_advanced_features.fluid
+++ b/src/xml/tests/test_advanced_features.fluid
@@ -94,14 +94,38 @@ end
 -- Test entity parsing
 
 function testEntityParsing()
-   local xmlWithEntities = '<!DOCTYPE root [<!ENTITY test "replacement">]><root>&test;</root>'
+   local xmlWithEntities = [[<!DOCTYPE root PUBLIC "-//Example//DTD Example//EN" "http://example.com/example.dtd" [
+      <!ENTITY % base "value">
+      <!ENTITY test "%base; and more">
+      <!NOTATION icon SYSTEM "viewer">
+   ]>
+   <root>&test;</root>]]
 
    -- Test with entity parsing enabled
    local xml = obj.new("xml", {
       statement = xmlWithEntities,
       flags = XMF_PARSE_ENTITY
    })
-   -- Entities should be processed when flag is set
+
+   assert(xml.documentType == 'root', 'Document type field should be populated')
+   assert(xml.publicID == '-//Example//DTD Example//EN', 'Public identifier should match declaration')
+   assert(xml.systemID == 'http://example.com/example.dtd', 'System identifier should match declaration')
+
+   local err, entityValue = xml.mtGetEntity('test')
+   assert(err == ERR_Okay and entityValue == 'value and more', 'Parsed entity should resolve parameter entities')
+
+   local notationErr, notationValue = xml.mtGetNotation('icon')
+   assert(notationErr == ERR_Okay and notationValue == 'viewer', 'Notation lookup should return the system identifier')
+
+   local info = struct.new('DTDInfo')
+   local infoErr = xml.mtGetDTDInfo(info)
+   assert(infoErr == ERR_Okay, 'GetDTDInfo should succeed')
+   assert(info.documentType == 'root', 'DTDInfo should copy the document type name')
+   assert(info.publicID == xml.publicID, 'DTDInfo should copy the public identifier')
+   assert(info.systemID == xml.systemID, 'DTDInfo should copy the system identifier')
+
+   local resolved = xml.getKey('string(/root)')
+   assert(resolved == 'value and more', 'Entity references should be expanded in content')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/xml/unescape.cpp
+++ b/src/xml/unescape.cpp
@@ -315,7 +315,7 @@ static void xml_unescape(extXML *Self, std::string &String)
                std::string resolved;
                if (Self->resolveEntity(lookup, resolved) IS ERR::Okay) {
                   String.replace(c, end - c, resolved);
-                  c += resolved.size();
+                  // Rescan the inserted text to handle nested entity references.
                }
                else c++;
             }

--- a/src/xml/unescape.cpp
+++ b/src/xml/unescape.cpp
@@ -311,7 +311,14 @@ static void xml_unescape(extXML *Self, std::string &String)
                String.replace(c, end-c, glOfficial[lookup]);
                c++;
             }
-            else if ((Self->Flags & XMF::PARSE_ENTITY) != XMF::NIL) c++; // Not yet implemented
+            else if ((Self->Flags & XMF::PARSE_ENTITY) != XMF::NIL) {
+               std::string resolved;
+               if (Self->resolveEntity(lookup, resolved) IS ERR::Okay) {
+                  String.replace(c, end - c, resolved);
+                  c += resolved.size();
+               }
+               else c++;
+            }
             else if ((Self->Flags & XMF::PARSE_HTML) != XMF::NIL) { // Process HTML escape codes
                if (glHTML.contains(lookup)) {
                   auto unicode = glHTML[lookup];

--- a/src/xml/xml.fdl
+++ b/src/xml/xml.fdl
@@ -43,7 +43,7 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
     "INSTRUCTION: Tag represents an instruction of the format `<?xml?>`.",
     "NOTATION: Tag represents a notation of the format `<!XML>`.",
     "COMMENT: Tag represents a comment of the format `<!-- Comment -->`.")
-
+    
   struct("XMLAttrib", { type="XMLAttrib" }, [[
    cpp(str) Name   # Name of the attribute
    cpp(str) Value  # Value of the attribute
@@ -108,12 +108,6 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
    }
   ]])
 
-  struct("DTDInfo", { type="DTDInfo" }, [[
-    cpp(str) DocumentType # DOCTYPE root name
-    cpp(str) PublicID     # DOCTYPE public identifier
-    cpp(str) SystemID     # DOCTYPE system identifier
-  ]])
-
   methods("xml", "XML", {
     { id=1,  name="SetAttrib" },
     { id=2,  name="Serialise" },
@@ -136,13 +130,12 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
     { id=22, name="ResolvePrefix" },
     { id=23, name="SetVariable" },
     { id=24, name="GetEntity" },
-    { id=25, name="GetNotation" },
-    { id=26, name="GetDTDInfo" }
+    { id=25, name="GetNotation" }
   })
 
   class("XML", { src="xml.cpp", output="xml_def.c" }, [[
     str Path         # Location of the XML data file
-    str DocumentType # Root element name from DOCTYPE declaration
+    str DocType      # Root element name from DOCTYPE declaration
     str PublicID     # Public identifier for external DTD
     str SystemID     # System identifier for external DTD
     obj Source       # Alternative data source to specifying a `Path`

--- a/src/xml/xml.fdl
+++ b/src/xml/xml.fdl
@@ -106,7 +106,13 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
       }
       return str.str();
    }
-   ]])
+  ]])
+
+  struct("DTDInfo", { type="DTDInfo" }, [[
+    cpp(str) DocumentType # DOCTYPE root name
+    cpp(str) PublicID     # DOCTYPE public identifier
+    cpp(str) SystemID     # DOCTYPE system identifier
+  ]])
 
   methods("xml", "XML", {
     { id=1,  name="SetAttrib" },
@@ -128,7 +134,10 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
     { id=20, name="GetNamespaceURI" },
     { id=21, name="SetTagNamespace" },
     { id=22, name="ResolvePrefix" },
-    { id=23, name="SetVariable" }
+    { id=23, name="SetVariable" },
+    { id=24, name="GetEntity" },
+    { id=25, name="GetNotation" },
+    { id=26, name="GetDTDInfo" }
   })
 
   class("XML", { src="xml.cpp", output="xml_def.c" }, [[

--- a/src/xml/xml.h
+++ b/src/xml/xml.h
@@ -124,6 +124,8 @@ class extXML : public objXML {
       StaleMap = true;
       Modified++;
    }
+
+   ERR resolveEntity(const std::string &Name, std::string &Value, bool Parameter = false);
    
    // XPath 1.0 Implementation for Parasol
    // 

--- a/src/xml/xml_def.c
+++ b/src/xml/xml_def.c
@@ -43,7 +43,6 @@ FDEF maResolvePrefix[] = { { "Prefix", FD_STR }, { "TagID", FD_INT }, { "Result"
 FDEF maSetVariable[] = { { "Key", FD_STR }, { "Value", FD_STR }, { 0, 0 } };
 FDEF maGetEntity[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
 FDEF maGetNotation[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
-FDEF maGetDTDInfo[] = { { "DTDInfo:Info", FD_PTR|FD_STRUCT }, { 0, 0 } };
 
 static const struct MethodEntry clXMLMethods[] = {
    { AC(-1), (APTR)XML_SetAttrib, "SetAttrib", maSetAttrib, sizeof(struct xml::SetAttrib) },
@@ -68,7 +67,6 @@ static const struct MethodEntry clXMLMethods[] = {
    { AC(-23), (APTR)XML_SetVariable, "SetVariable", maSetVariable, sizeof(struct xml::SetVariable) },
    { AC(-24), (APTR)XML_GetEntity, "GetEntity", maGetEntity, sizeof(struct xml::GetEntity) },
    { AC(-25), (APTR)XML_GetNotation, "GetNotation", maGetNotation, sizeof(struct xml::GetNotation) },
-   { AC(-26), (APTR)XML_GetDTDInfo, "GetDTDInfo", maGetDTDInfo, sizeof(struct xml::GetDTDInfo) },
    { AC::NIL, 0, 0, 0, 0 }
 };
 
@@ -86,4 +84,4 @@ static const struct ActionArray clXMLActions[] = {
 };
 
 #undef MOD_IDL
-#define MOD_IDL "s.XMLAttrib:zsName,zsValue\ns.XMLTag:lID,lParentID,lLineNo,lFlags,ulNamespaceID,zeAttribs:XMLAttrib[],zeChildren:XMLTag[]\ns.DTDInfo:zsDocumentType,zsPublicID,zsSystemID\nc.XMF:INCLUDE_COMMENTS=0x2,INCLUDE_SIBLINGS=0x80000000,INCLUDE_WHITESPACE=0x100,INDENT=0x8,LOCK_REMOVE=0x10,LOG_ALL=0x800,NAMESPACE_AWARE=0x4000,NEW=0x40,NO_ESCAPE=0x80,OMIT_TAGS=0x2000,PARSE_ENTITY=0x1000,PARSE_HTML=0x200,READABLE=0x8,STRIP_CDATA=0x400,STRIP_CONTENT=0x4,STRIP_HEADERS=0x20,WELL_FORMED=0x1\nc.XMI:CHILD=0x1,CHILD_END=0x3,END=0x4,NEXT=0x2,PREV=0x0,PREVIOUS=0x0\nc.XMS:NEW=0xffffffff,UPDATE=0xfffffffd,UPDATE_ONLY=0xfffffffe\nc.XSF:CHECK_SORT=0x2,DESC=0x1\nc.XTF:CDATA=0x1,COMMENT=0x8,INSTRUCTION=0x2,NOTATION=0x4\n"
+#define MOD_IDL "s.XMLAttrib:zsName,zsValue\ns.XMLTag:lID,lParentID,lLineNo,lFlags,ulNamespaceID,zeAttribs:XMLAttrib[],zeChildren:XMLTag[]\nc.XMF:INCLUDE_COMMENTS=0x2,INCLUDE_SIBLINGS=0x80000000,INCLUDE_WHITESPACE=0x100,INDENT=0x8,LOCK_REMOVE=0x10,LOG_ALL=0x800,NAMESPACE_AWARE=0x4000,NEW=0x40,NO_ESCAPE=0x80,OMIT_TAGS=0x2000,PARSE_ENTITY=0x1000,PARSE_HTML=0x200,READABLE=0x8,STRIP_CDATA=0x400,STRIP_CONTENT=0x4,STRIP_HEADERS=0x20,WELL_FORMED=0x1\nc.XMI:CHILD=0x1,CHILD_END=0x3,END=0x4,NEXT=0x2,PREV=0x0,PREVIOUS=0x0\nc.XMS:NEW=0xffffffff,UPDATE=0xfffffffd,UPDATE_ONLY=0xfffffffe\nc.XSF:CHECK_SORT=0x2,DESC=0x1\nc.XTF:CDATA=0x1,COMMENT=0x8,INSTRUCTION=0x2,NOTATION=0x4\n"

--- a/src/xml/xml_def.c
+++ b/src/xml/xml_def.c
@@ -41,6 +41,9 @@ FDEF maGetNamespaceURI[] = { { "NamespaceID", FD_INT|FD_UNSIGNED }, { "Result", 
 FDEF maSetTagNamespace[] = { { "TagID", FD_INT }, { "NamespaceID", FD_INT }, { 0, 0 } };
 FDEF maResolvePrefix[] = { { "Prefix", FD_STR }, { "TagID", FD_INT }, { "Result", FD_INT|FD_UNSIGNED|FD_RESULT }, { 0, 0 } };
 FDEF maSetVariable[] = { { "Key", FD_STR }, { "Value", FD_STR }, { 0, 0 } };
+FDEF maGetEntity[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
+FDEF maGetNotation[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
+FDEF maGetDTDInfo[] = { { "DTDInfo:Info", FD_PTR|FD_STRUCT }, { 0, 0 } };
 
 static const struct MethodEntry clXMLMethods[] = {
    { AC(-1), (APTR)XML_SetAttrib, "SetAttrib", maSetAttrib, sizeof(struct xml::SetAttrib) },
@@ -63,6 +66,9 @@ static const struct MethodEntry clXMLMethods[] = {
    { AC(-21), (APTR)XML_SetTagNamespace, "SetTagNamespace", maSetTagNamespace, sizeof(struct xml::SetTagNamespace) },
    { AC(-22), (APTR)XML_ResolvePrefix, "ResolvePrefix", maResolvePrefix, sizeof(struct xml::ResolvePrefix) },
    { AC(-23), (APTR)XML_SetVariable, "SetVariable", maSetVariable, sizeof(struct xml::SetVariable) },
+   { AC(-24), (APTR)XML_GetEntity, "GetEntity", maGetEntity, sizeof(struct xml::GetEntity) },
+   { AC(-25), (APTR)XML_GetNotation, "GetNotation", maGetNotation, sizeof(struct xml::GetNotation) },
+   { AC(-26), (APTR)XML_GetDTDInfo, "GetDTDInfo", maGetDTDInfo, sizeof(struct xml::GetDTDInfo) },
    { AC::NIL, 0, 0, 0, 0 }
 };
 
@@ -80,4 +86,4 @@ static const struct ActionArray clXMLActions[] = {
 };
 
 #undef MOD_IDL
-#define MOD_IDL "s.XMLAttrib:zsName,zsValue\ns.XMLTag:lID,lParentID,lLineNo,lFlags,ulNamespaceID,zeAttribs:XMLAttrib[],zeChildren:XMLTag[]\nc.XMF:INCLUDE_COMMENTS=0x2,INCLUDE_SIBLINGS=0x80000000,INCLUDE_WHITESPACE=0x100,INDENT=0x8,LOCK_REMOVE=0x10,LOG_ALL=0x800,NAMESPACE_AWARE=0x4000,NEW=0x40,NO_ESCAPE=0x80,OMIT_TAGS=0x2000,PARSE_ENTITY=0x1000,PARSE_HTML=0x200,READABLE=0x8,STRIP_CDATA=0x400,STRIP_CONTENT=0x4,STRIP_HEADERS=0x20,WELL_FORMED=0x1\nc.XMI:CHILD=0x1,CHILD_END=0x3,END=0x4,NEXT=0x2,PREV=0x0,PREVIOUS=0x0\nc.XMS:NEW=0xffffffff,UPDATE=0xfffffffd,UPDATE_ONLY=0xfffffffe\nc.XSF:CHECK_SORT=0x2,DESC=0x1\nc.XTF:CDATA=0x1,COMMENT=0x8,INSTRUCTION=0x2,NOTATION=0x4\n"
+#define MOD_IDL "s.XMLAttrib:zsName,zsValue\ns.XMLTag:lID,lParentID,lLineNo,lFlags,ulNamespaceID,zeAttribs:XMLAttrib[],zeChildren:XMLTag[]\ns.DTDInfo:zsDocumentType,zsPublicID,zsSystemID\nc.XMF:INCLUDE_COMMENTS=0x2,INCLUDE_SIBLINGS=0x80000000,INCLUDE_WHITESPACE=0x100,INDENT=0x8,LOCK_REMOVE=0x10,LOG_ALL=0x800,NAMESPACE_AWARE=0x4000,NEW=0x40,NO_ESCAPE=0x80,OMIT_TAGS=0x2000,PARSE_ENTITY=0x1000,PARSE_HTML=0x200,READABLE=0x8,STRIP_CDATA=0x400,STRIP_CONTENT=0x4,STRIP_HEADERS=0x20,WELL_FORMED=0x1\nc.XMI:CHILD=0x1,CHILD_END=0x3,END=0x4,NEXT=0x2,PREV=0x0,PREVIOUS=0x0\nc.XMS:NEW=0xffffffff,UPDATE=0xfffffffd,UPDATE_ONLY=0xfffffffe\nc.XSF:CHECK_SORT=0x2,DESC=0x1\nc.XTF:CDATA=0x1,COMMENT=0x8,INSTRUCTION=0x2,NOTATION=0x4\n"

--- a/src/xml/xml_functions.cpp
+++ b/src/xml/xml_functions.cpp
@@ -297,7 +297,11 @@ static void parse_doctype(extXML *Self, CSTRING Input)
                if (*str IS '%') { parameter = true; str++; skip_ws(str); }
 
                std::string name;
-               if (!read_name(str, name)) continue;
+               if (!read_name(str, name)) {
+                  while ((*str) and (*str != '>')) str++;
+                  if (*str IS '>') str++;
+                  continue;
+               }
 
                skip_ws(str);
 
@@ -325,7 +329,11 @@ static void parse_doctype(extXML *Self, CSTRING Input)
             else if (ci_keyword(str, "NOTATION")) {
                skip_ws(str);
                std::string name;
-               if (!read_name(str, name)) continue;
+               if (!read_name(str, name)) {
+                  while ((*str) and (*str != '>')) str++;
+                  if (*str IS '>') str++;
+                  continue;
+               }
                skip_ws(str);
 
                std::string notation_value;


### PR DESCRIPTION
## Summary
- add DTD parsing logic for <!DOCTYPE> declarations, capturing entity, parameter entity, and notation data
- expose parsed DOCTYPE metadata through new XML API methods and Fluid-accessible structures
- resolve custom entities during unescape and extend XML advanced tests to cover DOCTYPE information

## Testing
- cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/agents -DRUN_ANYWHERE=TRUE -DPARASOL_STATIC=OFF -DBUILD_DEFS=ON
- cmake --build build/agents --config Release --target xml -j 8
- ctest --build-config Release --test-dir build/agents -R xml *(fails: install tree not present in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d868795818832eac8081a4c6a8c1f4