### PR TITLE
Modernize XML parser string handling

### DIFF
--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -732,7 +732,8 @@ static ERR XML_InsertContent(extXML *Self, struct xml::InsertContent *Args)
    if (!src) return log.warning(ERR::NotFound);
 
    std::ostringstream buffer;
-   output_attribvalue(std::string(Args->Content), buffer);
+   auto content_view = view_or_empty(Args->Content);
+   output_attribvalue(content_view, buffer);
    XMLTag content(glTagID++, 0, { { "", buffer.str() } });
 
    if (Args->Where IS XMI::NEXT) {


### PR DESCRIPTION
## Summary
- modernize XML helper routines with std::string_view-aware whitespace, keyword, and quoted-value parsing to eliminate manual pointer arithmetic and reduce copies
- tighten DOCTYPE parsing by using string_view search utilities when skipping invalid declarations
- avoid temporary std::string construction when serialising inserted content

## Testing
- cmake --build build/agents --target xml -j 8

------
https://chatgpt.com/codex/tasks/task_e_68d887290208832e83428e8a08538e06