### PR TITLE
[XML] Performance Improvements; Bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ For Fluid code, verify:
 - Always use lower snake_case for the names of variables inside C++ and Fluid functions.
 - Use three spaces for tabulation in C++ and Fluid code.
 - C++ functions that use global variables must be written with thread safety in mind.
-- Use modern C++ conventions where possible, up to and including C++20 features.
+- Use modern C++ conventions, targeting features up to and including C++20.
 - C++ global variables are prefixed with `gl` and written in upper camel-case, e.g. `glSomeVariable`
 - Always default to British English spelling in code and comments.
 

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -606,7 +606,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     <field>
       <name>DocType</name>
       <comment>Root element name from DOCTYPE declaration</comment>
-      <access read="R">Read</access>
+      <access read="R" write="S">Read/Set</access>
       <type>STRING</type>
     </field>
 
@@ -654,7 +654,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     <field>
       <name>PublicID</name>
       <comment>Public identifier for external DTD</comment>
-      <access read="R">Read</access>
+      <access read="R" write="S">Read/Set</access>
       <type>STRING</type>
     </field>
 
@@ -705,7 +705,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     <field>
       <name>SystemID</name>
       <comment>System identifier for external DTD</comment>
-      <access read="R">Read</access>
+      <access read="R" write="S">Read/Set</access>
       <type>STRING</type>
     </field>
 

--- a/include/parasol/modules/xml.h
+++ b/include/parasol/modules/xml.h
@@ -378,6 +378,24 @@ class objXML : public Object {
       return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
    }
 
+   template <class T> inline ERR setDocType(T && Value) noexcept {
+      auto target = this;
+      auto field = &this->Class->Dictionary[9];
+      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   }
+
+   template <class T> inline ERR setPublic(T && Value) noexcept {
+      auto target = this;
+      auto field = &this->Class->Dictionary[17];
+      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   }
+
+   template <class T> inline ERR setSystem(T && Value) noexcept {
+      auto target = this;
+      auto field = &this->Class->Dictionary[7];
+      return field->WriteValue(target, field, 0x08800300, to_cstring(Value), 1);
+   }
+
    inline ERR setSource(OBJECTPTR Value) noexcept {
       if (this->initialised()) return ERR::NoFieldAccess;
       this->Source = Value;

--- a/include/parasol/strings.hpp
+++ b/include/parasol/strings.hpp
@@ -273,11 +273,12 @@ inline int strcopy(T &&Source, std::span<char, N> Dest) noexcept
 [[nodiscard]] inline STRING strclone(const std::string_view String) noexcept
 {
    STRING newstr;
-   if (AllocMemory(String.size()+1, MEM::STRING, (APTR *)&newstr, NULL) IS ERR::Okay) {
-      copymem(String.data(), newstr, String.size()+1);
+   if (AllocMemory(String.size()+1, MEM::STRING|MEM::NO_CLEAR, (APTR *)&newstr, nullptr) IS ERR::Okay) {
+      copymem(String.data(), newstr, String.size());
+      newstr[String.size()] = 0;
       return newstr;
    }
-   else return NULL;
+   else return nullptr;
 }
 
 // std::string_view conversion to numeric type.  Returns zero on error.
@@ -305,7 +306,7 @@ inline ERR set_string_field(const std::string_view Source, STRING &Dest)
       }
       else {
          FreeResource(GetMemoryID(Dest));
-         if (AllocMemory(Source.size() + 1, MEM::STRING|MEM::NO_CLEAR, (APTR *)&Dest, NULL) IS ERR::Okay) {
+         if (AllocMemory(Source.size() + 1, MEM::STRING|MEM::NO_CLEAR, (APTR *)&Dest, nullptr) IS ERR::Okay) {
             copymem(Source.data(), Dest, Source.size());
             Dest[Source.size()] = 0;
             return ERR::Okay;

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -1714,6 +1714,17 @@ static ERR XML_SetVariable(extXML *Self, struct xml::SetVariable *Args)
 -FIELD-
 DocType: Root element name from DOCTYPE declaration
 
+*********************************************************************************************************************/
+
+static ERR SET_DocType(extXML *Self, CSTRING Value)
+{
+   if (Value) return pf::set_string_field(Value, Self->DocType);
+   else if (Self->DocType) { FreeResource(Self->DocType); Self->DocType = nullptr; }
+   return ERR::Okay;
+}
+
+/*********************************************************************************************************************
+
 -FIELD-
 ErrorMsg: A textual description of the last parse error.
 
@@ -1788,8 +1799,30 @@ difference.
 -FIELD-
 PublicID: Public identifier for external DTD
 
+*********************************************************************************************************************/
+
+static ERR SET_PublicID(extXML *Self, CSTRING Value)
+{
+   if (Value) return pf::set_string_field(Value, Self->PublicID);
+   else if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
+   return ERR::Okay;
+}
+
+/*********************************************************************************************************************
+
 -FIELD-
 SystemID: System identifier for external DTD
+
+*********************************************************************************************************************/
+
+static ERR SET_SystemID(extXML *Self, CSTRING Value)
+{
+   if (Value) return pf::set_string_field(Value, Self->SystemID);
+   else if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
+   return ERR::Okay;
+}
+
+/*********************************************************************************************************************
 
 -FIELD-
 ReadOnly: Prevents modifications and enables caching for a loaded XML data source.
@@ -1961,9 +1994,9 @@ static ERR GET_Tags(extXML *Self, XMLTag **Values, int *Elements)
 
 static const FieldArray clFields[] = {
    { "Path",         FDF_STRING|FDF_RW, nullptr, SET_Path },
-   { "DocType",      FDF_STRING|FDF_R },
-   { "PublicID",     FDF_STRING|FDF_R },
-   { "SystemID",     FDF_STRING|FDF_R },
+   { "DocType",      FDF_STRING|FDF_RW, nullptr, SET_DocType },
+   { "PublicID",     FDF_STRING|FDF_RW, nullptr, SET_PublicID },
+   { "SystemID",     FDF_STRING|FDF_RW, nullptr, SET_SystemID },
    { "Source",       FDF_OBJECT|FDF_RI },
    { "Flags",        FDF_INTFLAGS|FDF_RW, nullptr, nullptr, &clXMLFlags },
    { "Start",        FDF_INT|FDF_RW },

--- a/src/xml/xml_functions.cpp
+++ b/src/xml/xml_functions.cpp
@@ -21,7 +21,7 @@ static void output_attribvalue(std::string_view String, std::ostringstream &Outp
    }
 }
 
-inline void assign_string(STRING &Target, const std::string &Value)
+inline void assign_string(STRING &Target, const std::string_view Value)
 {
    if (Target) { FreeResource(Target); Target = nullptr; }
    if (not Value.empty()) Target = pf::strclone(Value);
@@ -230,7 +230,7 @@ static void parse_doctype(extXML *Self, ParseState &State)
    auto type_view = read_name(view);
    if (type_view.empty()) return;
 
-   assign_string(Self->DocType, std::string(type_view));
+   assign_string(Self->DocType, type_view);
    if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
    if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }
    Self->Entities.clear();


### PR DESCRIPTION
This pull request introduces several improvements and optimizations to the XML module, focusing on performance, code clarity, and new setter functionality for key fields. The major changes include replacing standard containers with `ankerl::unordered_dense` for faster lookups, optimizing XML character escaping, adding setter methods for `DocType`, `PublicID`, and `SystemID`, and enhancing attribute parsing logic for efficiency and correctness.
