### PR TITLE
Implement XPath 2.0 error and trace functions

### DIFF
--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -188,6 +188,8 @@ class XPathFunctionLibrary {
    static XPathValue function_lower_case(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_encode_for_uri(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_escape_html_uri(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_error(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_trace(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_boolean(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_not(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_true(const std::vector<XPathValue> &Args, const XPathContext &Context);


### PR DESCRIPTION
## Summary
- add a diagnostic formatter for XPath values so trace/error output is readable
- register the XPath 2.0 `error` and `trace` functions in the core function library
- implement both functions with logging and error propagation to the XML document state

## Testing
- cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=FastBuild -DCMAKE_INSTALL_PREFIX=install/agents -DRUN_ANYWHERE=TRUE -DPARASOL_STATIC=OFF -DBUILD_DEFS=ON -DDISABLE_AUDIO=ON -DDISABLE_X11=ON -DDISABLE_DISPLAY=ON -DDISABLE_FONT=ON
- cmake --build build/agents --target xml -j 8


------
https://chatgpt.com/codex/tasks/task_e_68d9d37fcfa8832e8e047299d3333b31