### PR TITLE
Add XPath 2.0 round-half-to-even function

### DIFF
--- a/src/xml/tests/test_xpath_func_ext.fluid
+++ b/src/xml/tests/test_xpath_func_ext.fluid
@@ -69,6 +69,31 @@ function testMathFunctions()
 
    local err4, avgNode = xml.mtFindTag('/root/value[@amount = round(avg(/root/value/@amount))]')
    assert(err4 == ERR_Okay, "avg() should locate the middle item")
+
+   local xmlRound = obj.new("xml", {
+      statement = '<root><case id="tie-low" value="0.5"/><case id="tie-high" value="1.5"/><case id="tie-upper" value="2.5"/><case id="negative" value="-1.5"/><case id="precision" value="123.455"/><case id="precision-even" value="123.445"/><case id="neg-precision" value="1250"/></root>'
+   })
+
+   local errTieLow, tieLowId = xmlRound.mtFindTag('/root/case[@id = "tie-low" and round-half-to-even(number(@value)) = 0]')
+   assert(errTieLow == ERR_Okay, 'round-half-to-even() should round 0.5 to the even integer 0')
+
+   local errTieHigh, tieHighId = xmlRound.mtFindTag('/root/case[@id = "tie-high" and round-half-to-even(number(@value)) = 2]')
+   assert(errTieHigh == ERR_Okay, 'round-half-to-even() should round 1.5 up to the even integer 2')
+
+   local errTieUpper, tieUpperId = xmlRound.mtFindTag('/root/case[@id = "tie-upper" and round-half-to-even(number(@value)) = 2]')
+   assert(errTieUpper == ERR_Okay, 'round-half-to-even() should round 2.5 down to the even integer 2')
+
+   local errNegative, negativeId = xmlRound.mtFindTag('/root/case[@id = "negative" and round-half-to-even(number(@value)) = -2]')
+   assert(errNegative == ERR_Okay, 'round-half-to-even() should honour even rounding for negative ties')
+
+   local errPrecision, precisionId = xmlRound.mtFindTag('/root/case[@id = "precision" and round-half-to-even(number(@value), 2) = 123.46]')
+   assert(errPrecision == ERR_Okay, 'round-half-to-even() should round fractional precision ties upward when the preceding digit is odd')
+
+   local errPrecisionEven, precisionEvenId = xmlRound.mtFindTag('/root/case[@id = "precision-even" and round-half-to-even(number(@value), 2) = 123.44]')
+   assert(errPrecisionEven == ERR_Okay, 'round-half-to-even() should leave even fractional digits unchanged when exactly halfway')
+
+   local errNegPrecision, negPrecisionId = xmlRound.mtFindTag('/root/case[@id = "neg-precision" and round-half-to-even(number(@value), -2) = 1200]')
+   assert(errNegPrecision == ERR_Okay, 'round-half-to-even() should support negative precision arguments')
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -201,6 +201,7 @@ class XPathFunctionLibrary {
    static XPathValue function_floor(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_ceiling(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_round(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_round_half_to_even(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_abs(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_min(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_max(const std::vector<XPathValue> &Args, const XPathContext &Context);


### PR DESCRIPTION
## Summary
- register the XPath 2.0 `round-half-to-even` function and implement banker's rounding with precision handling
- expand the XML function extension tests to cover rounding ties, fractional precision, and negative precision cases

## Testing
- `cmake --build build/agents -j 8`
- `cmake --install build/agents`
- `cd src/xml/tests && ../../../install/agents/parasol ../../../tools/flute.fluid file=/workspace/parasol/src/xml/tests/test_xpath_func_ext.fluid --gfx-driver=headless --log-warning`


------
https://chatgpt.com/codex/tasks/task_e_68da5c52210c832eb153adba9acc5521