### PR TITLE
Implement XPath 2.0 duration helpers

### DIFF
--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -30,6 +30,7 @@ flute_test (${MOD}_variables "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_setvariable
 flute_test (${MOD}_xpath_func_ext "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_func_ext.fluid")
 flute_test (${MOD}_xpath_sequences "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_sequences.fluid")
 flute_test (${MOD}_xpath_string_uri "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath_string_uri.fluid")
+flute_test (${MOD}_xpath2_duration "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath2_duration.fluid")
 
 if (INSTALL_TESTS)
    add_executable (test_xml_count_debug "tests/test_count_debug.cpp")

--- a/src/xml/tests/test_xpath2_duration.fluid
+++ b/src/xml/tests/test_xpath2_duration.fluid
@@ -1,0 +1,72 @@
+-- XPath 2.0 duration helper tests
+
+   include 'xml'
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Validate component extraction from general xs:duration values
+
+function testGeneralDurationComponents()
+   local xml = obj.new("xml", {
+      statement = '<root>'
+         .. '<duration id="ym" value="P2Y11M"/>'
+         .. '<duration id="days" value="P30D"/>'
+         .. '<duration id="time" value="PT30.5S"/>'
+         .. '<duration id="negative" value="-P1Y2M3DT4H5M6S"/>'
+         .. '<duration id="mixed" value="P1Y2M3DT4H5M6.25S"/>'
+         .. '</root>'
+   })
+
+   local errYears, yearsNode = xml.mtFindTag('/root/duration[@id = "ym" and years-from-duration(@value) = 2 and months-from-duration(@value) = 11]')
+   assert(errYears == ERR_Okay and yearsNode != nil, 'years-from-duration() should extract the year component from xs:duration values')
+
+   local errDays, daysNode = xml.mtFindTag('/root/duration[@id = "days" and days-from-duration(@value) = 30]')
+   assert(errDays == ERR_Okay and daysNode != nil, 'days-from-duration() should decode day quantities from xs:duration values')
+
+   local errSeconds, secondsNode = xml.mtFindTag('/root/duration[@id = "time" and seconds-from-duration(@value) = 30.5]')
+   assert(errSeconds == ERR_Okay and secondsNode != nil, 'seconds-from-duration() should honour fractional seconds within xs:duration values')
+
+   local errNegative, negativeNode = xml.mtFindTag('/root/duration[@id = "negative" and years-from-duration(@value) = -1 and months-from-duration(@value) = -2 and days-from-duration(@value) = -3 and hours-from-duration(@value) = -4 and minutes-from-duration(@value) = -5 and seconds-from-duration(@value) = -6]')
+   assert(errNegative == ERR_Okay and negativeNode != nil, 'duration component helpers should propagate the sign of negative xs:duration values')
+
+   local errMixed, mixedNode = xml.mtFindTag('/root/duration[@id = "mixed" and hours-from-duration(@value) = 4 and minutes-from-duration(@value) = 5 and round(seconds-from-duration(@value) * 100) = 625]')
+   assert(errMixed == ERR_Okay and mixedNode != nil, 'duration helpers should parse combined date and time components including fractional seconds')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+-- Validate specialised yearMonthDuration and dayTimeDuration helpers
+
+function testSpecificDurationTypes()
+   local xml = obj.new("xml", {
+      statement = '<root>'
+         .. '<duration id="ym-positive" value="P3Y4M"/>'
+         .. '<duration id="ym-negative" value="-P1Y2M"/>'
+         .. '<duration id="dt" value="P5DT6H7M8.25S"/>'
+         .. '<duration id="dt-negative" value="-P0DT12H30M45S"/>'
+         .. '</root>'
+   })
+
+   local errYmPositive, ymPositiveNode = xml.mtFindTag('/root/duration[@id = "ym-positive" and years-from-yearMonthDuration(@value) = 3 and months-from-yearMonthDuration(@value) = 4]')
+   assert(errYmPositive == ERR_Okay and ymPositiveNode != nil, 'years-from-yearMonthDuration() should expose the year field of xs:yearMonthDuration values')
+
+   local errYmNegative, ymNegativeNode = xml.mtFindTag('/root/duration[@id = "ym-negative" and years-from-yearMonthDuration(@value) = -1 and months-from-yearMonthDuration(@value) = -2]')
+   assert(errYmNegative == ERR_Okay and ymNegativeNode != nil, 'months-from-yearMonthDuration() should apply duration signs to the extracted month component')
+
+   local errDayTime, dayTimeNode = xml.mtFindTag('/root/duration[@id = "dt" and days-from-dayTimeDuration(@value) = 5 and hours-from-dayTimeDuration(@value) = 6 and minutes-from-dayTimeDuration(@value) = 7 and round(seconds-from-dayTimeDuration(@value) * 100) = 825]')
+   assert(errDayTime == ERR_Okay and dayTimeNode != nil, 'dayTimeDuration helpers should decode combined day and time components, including fractional seconds')
+
+   local errDayTimeNegative, dayTimeNegativeNode = xml.mtFindTag('/root/duration[@id = "dt-negative" and days-from-dayTimeDuration(@value) = 0 and hours-from-dayTimeDuration(@value) = -12 and minutes-from-dayTimeDuration(@value) = -30 and seconds-from-dayTimeDuration(@value) = -45]')
+   assert(errDayTimeNegative == ERR_Okay and dayTimeNegativeNode != nil, 'dayTimeDuration helpers should respect negative values across all components')
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+
+return {
+   tests = {
+      'testGeneralDurationComponents',
+      'testSpecificDurationTypes'
+   },
+   init = function(ScriptFolder)
+   end,
+   cleanup = function()
+   end
+}

--- a/src/xml/tests/test_xpath2_duration.fluid
+++ b/src/xml/tests/test_xpath2_duration.fluid
@@ -9,8 +9,10 @@ function testGeneralDurationComponents()
    local xml = obj.new("xml", {
       statement = '<root>'
          .. '<duration id="ym" value="P2Y11M"/>'
+         .. '<duration id="carry-months" value="P14M"/>'
          .. '<duration id="days" value="P30D"/>'
          .. '<duration id="time" value="PT30.5S"/>'
+         .. '<duration id="carry-time" value="PT48H30M90S"/>'
          .. '<duration id="negative" value="-P1Y2M3DT4H5M6S"/>'
          .. '<duration id="mixed" value="P1Y2M3DT4H5M6.25S"/>'
          .. '</root>'
@@ -19,11 +21,17 @@ function testGeneralDurationComponents()
    local errYears, yearsNode = xml.mtFindTag('/root/duration[@id = "ym" and years-from-duration(@value) = 2 and months-from-duration(@value) = 11]')
    assert(errYears == ERR_Okay and yearsNode != nil, 'years-from-duration() should extract the year component from xs:duration values')
 
+   local errCarryMonths, carryMonthsNode = xml.mtFindTag('/root/duration[@id = "carry-months" and years-from-duration(@value) = 1 and months-from-duration(@value) = 2]')
+   assert(errCarryMonths == ERR_Okay and carryMonthsNode != nil, 'duration helpers should normalise months into canonical year and month components')
+
    local errDays, daysNode = xml.mtFindTag('/root/duration[@id = "days" and days-from-duration(@value) = 30]')
    assert(errDays == ERR_Okay and daysNode != nil, 'days-from-duration() should decode day quantities from xs:duration values')
 
    local errSeconds, secondsNode = xml.mtFindTag('/root/duration[@id = "time" and seconds-from-duration(@value) = 30.5]')
    assert(errSeconds == ERR_Okay and secondsNode != nil, 'seconds-from-duration() should honour fractional seconds within xs:duration values')
+
+   local errCarryTime, carryTimeNode = xml.mtFindTag('/root/duration[@id = "carry-time" and days-from-duration(@value) = 2 and hours-from-duration(@value) = 0 and minutes-from-duration(@value) = 31 and seconds-from-duration(@value) = 30]')
+   assert(errCarryTime == ERR_Okay and carryTimeNode != nil, 'duration helpers should carry overflowed time fields into neighbouring units before extraction')
 
    local errNegative, negativeNode = xml.mtFindTag('/root/duration[@id = "negative" and years-from-duration(@value) = -1 and months-from-duration(@value) = -2 and days-from-duration(@value) = -3 and hours-from-duration(@value) = -4 and minutes-from-duration(@value) = -5 and seconds-from-duration(@value) = -6]')
    assert(errNegative == ERR_Okay and negativeNode != nil, 'duration component helpers should propagate the sign of negative xs:duration values')

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -235,6 +235,24 @@ class XPathFunctionLibrary {
    static XPathValue function_current_date(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_current_time(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_current_date_time(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_years_from_duration(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_months_from_duration(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_days_from_duration(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_hours_from_duration(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_minutes_from_duration(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_seconds_from_duration(const std::vector<XPathValue> &Args, const XPathContext &Context);
+   static XPathValue function_years_from_year_month_duration(const std::vector<XPathValue> &Args,
+      const XPathContext &Context);
+   static XPathValue function_months_from_year_month_duration(const std::vector<XPathValue> &Args,
+      const XPathContext &Context);
+   static XPathValue function_days_from_day_time_duration(const std::vector<XPathValue> &Args,
+      const XPathContext &Context);
+   static XPathValue function_hours_from_day_time_duration(const std::vector<XPathValue> &Args,
+      const XPathContext &Context);
+   static XPathValue function_minutes_from_day_time_duration(const std::vector<XPathValue> &Args,
+      const XPathContext &Context);
+   static XPathValue function_seconds_from_day_time_duration(const std::vector<XPathValue> &Args,
+      const XPathContext &Context);
    static XPathValue function_matches(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_replace(const std::vector<XPathValue> &Args, const XPathContext &Context);
    static XPathValue function_tokenize(const std::vector<XPathValue> &Args, const XPathContext &Context);


### PR DESCRIPTION
## Summary
- add reusable parsing helpers for xs:duration strings and expose new XPath extraction functions
- register the new duration helpers in the function library interface and header
- add a Flute regression that covers xs:duration, xs:yearMonthDuration, and xs:dayTimeDuration extraction functions

## Testing
- cmake --build build/agents --target xml -j 8
- cmake --install build/agents *(fails: install target expects build of http module producing release/lib/http.so which is skipped in this environment)*
- ctest --build-config FastBuild --test-dir build/agents -R xml_xpath2_duration *(fails: installed parasol binary missing because install step above did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68dab3cb2d40832e928c1f642b03346f