### PR TITLE
Build XML XPath functions from object library

### DIFF
--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -12,7 +12,15 @@ target_link_libraries (${MOD} PUBLIC unicode)
 target_link_libraries (${MOD} PRIVATE link_regex)
 set_module_defaults (${MOD} "Xml")
 
-target_sources (${MOD} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/${MOD}.cpp")
+add_library (xml_xpath_functions OBJECT "${CMAKE_CURRENT_SOURCE_DIR}/xpath/xpath_functions.cpp")
+target_include_directories (xml_xpath_functions PRIVATE "${PROJECT_SOURCE_DIR}/include")
+target_compile_definitions (xml_xpath_functions PRIVATE "MOD_NAME=${MOD}" "MOD_NAMESPACE=Xml")
+set_target_properties (xml_xpath_functions PROPERTIES CXX_STANDARD 20 POSITION_INDEPENDENT_CODE ON)
+add_dependencies (xml_xpath_functions build_headers)
+
+target_sources (${MOD} PRIVATE
+   "${CMAKE_CURRENT_SOURCE_DIR}/${MOD}.cpp"
+   $<TARGET_OBJECTS:xml_xpath_functions>)
 
 flute_test (${MOD}_basic "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_basic.fluid")
 flute_test (${MOD}_advanced "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_advanced_features.fluid")

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -70,7 +70,6 @@ static uint32_t glTagID = 1;
 #include "unescape.cpp"
 #include "xml_functions.cpp"
 #include "xpath/xpath_ast.cpp"
-#include "xpath/xpath_functions.cpp"
 #include "xpath/xpath_axis.cpp"
 #include "xpath/xpath_parser.cpp"
 #include "xpath/xpath_evaluator.h"

--- a/src/xml/xml.h
+++ b/src/xml/xml.h
@@ -321,7 +321,7 @@ static ERR SET_Source(extXML *, OBJECTPTR);
 #include "xpath/xpath_parser.h"
 #include "xpath/xpath_evaluator.h"
 
-ERR extXML::findTag(CSTRING XPath, FUNCTION *pCallback) 
+inline ERR extXML::findTag(CSTRING XPath, FUNCTION *pCallback)
 {
    auto compiled_path = CompiledXPath::compile(XPath);
    if (not compiled_path.isValid()) {
@@ -335,7 +335,7 @@ ERR extXML::findTag(CSTRING XPath, FUNCTION *pCallback)
    return findTag(compiled_path, pCallback);
 }
 
-ERR extXML::findTag(const CompiledXPath &CompiledPath, FUNCTION *pCallback)
+inline ERR extXML::findTag(const CompiledXPath &CompiledPath, FUNCTION *pCallback)
 {
    this->Attrib.clear();
 
@@ -356,7 +356,7 @@ ERR extXML::findTag(const CompiledXPath &CompiledPath, FUNCTION *pCallback)
    return eval.find_tag(CompiledPath, 0);
 }
 
-ERR extXML::evaluate(CSTRING XPath, std::string &Result) 
+inline ERR extXML::evaluate(CSTRING XPath, std::string &Result)
 {
    auto compiled_path = CompiledXPath::compile(XPath);
    if (not compiled_path.isValid()) {
@@ -370,7 +370,7 @@ ERR extXML::evaluate(CSTRING XPath, std::string &Result)
    return evaluate(compiled_path, Result);
 }
 
-ERR extXML::evaluate(const CompiledXPath &CompiledPath, std::string &Result)
+inline ERR extXML::evaluate(const CompiledXPath &CompiledPath, std::string &Result)
 {
    this->Attrib.clear();
    this->CursorTags = &this->Tags;

--- a/src/xml/xpath/xpath_functions.cpp
+++ b/src/xml/xpath/xpath_functions.cpp
@@ -15,6 +15,9 @@
 // namespace-aware functions or performance-focused helpers) without polluting the evaluator with
 // coercion details.
 
+#include <parasol/modules/xml.h>
+#include <parasol/strings.hpp>
+
 #include "xpath_functions.h"
 #include "../xml.h"
 

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -7,7 +7,14 @@
 
 #pragma once
 
+#include <parasol/main.h>
 #include <ankerl/unordered_dense.h>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
 
 struct TransparentStringHash {
    using is_transparent = void;


### PR DESCRIPTION
## Summary
- build the XPath function implementation as an object target and link it into the XML module
- update XML headers and includes so the XPath functions compile independently of xml.cpp

## Testing
- `cmake --build build/agents --target xml --parallel`


------
https://chatgpt.com/codex/tasks/task_e_68dba03fc130832e974e5e0566ee61c5