### PR TITLE
Integrate schema-aware XPath comparisons

### DIFF
--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -60,6 +60,7 @@ class XPathEvaluator {
    explicit XPathEvaluator(extXML *XML) : xml(XML), axis_evaluator(XML, arena) {
       context.document = XML;
       context.expression_unsupported = &expression_unsupported;
+      context.schema_registry = &xml::schema::registry();
    }
 
    ERR evaluate_ast(const XPathNode *Node, uint32_t CurrentPrefix);

--- a/src/xml/xpath/xpath_functions.h
+++ b/src/xml/xpath/xpath_functions.h
@@ -115,7 +115,13 @@ class XPathValue
 //********************************************************************************************************************
 // XPath Evaluation Context
 
-struct XPathContext 
+namespace xml::schema
+{
+   class SchemaTypeRegistry;
+   SchemaTypeRegistry & registry();
+}
+
+struct XPathContext
 {
    XMLTag * context_node = nullptr;
    const XMLAttrib * attribute_node = nullptr;
@@ -124,12 +130,14 @@ struct XPathContext
    ankerl::unordered_dense::map<std::string, XPathValue> variables;
    extXML * document = nullptr;
    bool * expression_unsupported = nullptr;
+   xml::schema::SchemaTypeRegistry * schema_registry = nullptr;
 
    XPathContext() = default;
    XPathContext(XMLTag *Node, size_t cursor = 1, size_t Sz = 1, const XMLAttrib *Attribute = nullptr,
-                extXML *Document = nullptr, bool *UnsupportedFlag = nullptr)
+                extXML *Document = nullptr, bool *UnsupportedFlag = nullptr,
+                xml::schema::SchemaTypeRegistry *Registry = nullptr)
       : context_node(Node), attribute_node(Attribute), position(cursor), size(Sz), document(Document),
-        expression_unsupported(UnsupportedFlag) {}
+        expression_unsupported(UnsupportedFlag), schema_registry(Registry) {}
 };
 
 class VariableBindingGuard


### PR DESCRIPTION
## Summary
- add schema descriptor helpers and use them when comparing XPath values to respect schema metadata
- teach XPathValue conversions to interpret schema-typed values, including canonical boolean parsing and numeric formatting
- expose the schema registry through XPathContext so the evaluator can access schema information during evaluation

## Testing
- cmake --build build/agents --config FastBuild --target xml --parallel

------
https://chatgpt.com/codex/tasks/task_e_68dbe0231150832e996940ed3c0d334c