### PR TITLE
Implement XML schema validation support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ For Fluid code, verify:
 - C++ functions that use global variables must be written with thread safety in mind.
 - Use modern C++ conventions, targeting features up to and including C++20.
 - C++ global variables are prefixed with `gl` and written in upper camel-case, e.g. `glSomeVariable`
+- The default column width is 120 characters for all languages.
 - Always default to British English spelling in code and comments.
 
 ### Testing
@@ -286,3 +287,4 @@ Lower snake-case is the preferred string format for new file names.
 ## Agentic Behaviour
 
 - Always give an honest, balanced opinion in your responses
+- Encourage testing and validation of changes

--- a/docs/xml/modules/classes/xml.xml
+++ b/docs/xml/modules/classes/xml.xml
@@ -386,6 +386,24 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
     </method>
 
     <method>
+      <name>LoadSchema</name>
+      <comment>Load an XML Schema definition to enable schema-aware validation.</comment>
+      <prototype>ERR xml::LoadSchema(OBJECTPTR Object, CSTRING Path)</prototype>
+      <input>
+        <param type="CSTRING" name="Path">File system path to the XML Schema (XSD) document.</param>
+      </input>
+      <description>
+<p>This method parses an XML Schema document and attaches its schema context to the current XML object.  Once loaded, schema metadata is available for validation and XPath evaluation routines that utilise schema-aware behaviour.</p>
+      </description>
+      <result>
+        <error code="Okay">Schema was successfully loaded and parsed.</error>
+        <error code="NoData">The schema document did not contain any parsable definitions.</error>
+        <error code="CreateObject">The file in Path could not be processed as XML content.</error>
+        <error code="NullArgs">The Path argument was not provided.</error>
+      </result>
+    </method>
+
+    <method>
       <name>MoveTags</name>
       <comment>Move an XML tag group to a new position in the XML tree.</comment>
       <prototype>ERR xml::MoveTags(OBJECTPTR Object, INT Index, INT Total, INT DestIndex, XMI Where)</prototype>
@@ -600,6 +618,22 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
       </result>
     </method>
 
+    <method>
+      <name>ValidateDocument</name>
+      <comment>Validate the XML document against the currently loaded schema.</comment>
+      <prototype>ERR xml::ValidateDocument(OBJECTPTR Object)</prototype>
+      <description>
+<p>This method performs structural and simple type validation of the document using the loaded XML Schema.  The Result parameter returns <code>1</code> when the document conforms to the schema, otherwise <code>0</code>.</p>
+      </description>
+      <result>
+        <error code="Okay">Validation completed successfully.</error>
+        <error code="Search">The schema does not define the root element present in the document.</error>
+        <error code="NoData">The XML document does not contain any parsed tags.</error>
+        <error code="NoSupport">No schema has been loaded for this XML object.</error>
+        <error code="NullArgs">The Result parameter was not supplied.</error>
+      </result>
+    </method>
+
   </methods>
 
   <fields>
@@ -725,6 +759,7 @@ local err = xml.acDataFeed(nil, DATA_XML, '<first>First element</first>')
   </fields>
   <types>
     <constants lookup="XMF" comment="Standard flags for the XML class.">
+      <const name="HAS_SCHEMA">Automatically defined when a schema has been loaded into the XML object.</const>
       <const name="INCLUDE_COMMENTS">By default, comments are stripped when parsing XML input unless this flag is specified.</const>
       <const name="INCLUDE_SIBLINGS">Include siblings when building an XML string (<action>GetXMLString</action> only)</const>
       <const name="INCLUDE_WHITESPACE">By default the XML parser will skip content between tags when they contain pure whitespace.  Setting this flag will retain all whitespace.</const>

--- a/include/parasol/modules/xml.h
+++ b/include/parasol/modules/xml.h
@@ -10,7 +10,6 @@
 
 #ifdef __cplusplus
 #include <functional>
-#include <memory>
 #include <sstream>
 #ifndef STRINGS_HPP
 #include <parasol/strings.hpp>
@@ -19,11 +18,6 @@
 #endif
 
 class objXML;
-
-namespace xml::schema
-{
-   struct SchemaContext;
-}
 
 // For SetAttrib()
 
@@ -64,6 +58,7 @@ enum class XMF : uint32_t {
    PARSE_ENTITY = 0x00001000,
    OMIT_TAGS = 0x00002000,
    NAMESPACE_AWARE = 0x00004000,
+   HAS_SCHEMA = 0x00008000,
    INCLUDE_SIBLINGS = 0x80000000,
 };
 
@@ -191,8 +186,7 @@ struct SetVariable { CSTRING Key; CSTRING Value; static const AC id = AC(-23); E
 struct GetEntity { CSTRING Name; CSTRING Value; static const AC id = AC(-24); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetNotation { CSTRING Name; CSTRING Value; static const AC id = AC(-25); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct LoadSchema { CSTRING Path; static const AC id = AC(-26); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct ValidateDocument { int Result; static const AC id = AC(-27); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
-struct HasSchema { int Result; static const AC id = AC(-28); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ValidateDocument { static const AC id = AC(-27); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -217,7 +211,6 @@ class objXML : public Object {
    typedef pf::vector<XMLTag> TAGS;
    typedef pf::vector<XMLTag>::iterator CURSOR;
    TAGS Tags;
-   std::shared_ptr<xml::schema::SchemaContext> schema_context;
 
    template <class T> inline ERR insertStatement(int Index, XMI Where, T Statement, XMLTag **Result) {
       int index_result;
@@ -383,17 +376,8 @@ class objXML : public Object {
       struct xml::LoadSchema args = { Path };
       return(Action(AC(-26), this, &args));
    }
-   inline ERR validateDocument(int * Result) noexcept {
-      struct xml::ValidateDocument args = { 0 };
-      ERR error = Action(AC(-27), this, &args);
-      if (Result) *Result = args.Result;
-      return(error);
-   }
-   inline ERR hasSchema(int * Result) noexcept {
-      struct xml::HasSchema args = { 0 };
-      ERR error = Action(AC(-28), this, &args);
-      if (Result) *Result = args.Result;
-      return(error);
+   inline ERR validateDocument() noexcept {
+      return(Action(AC(-27), this, nullptr));
    }
 
    // Customised field setting

--- a/include/parasol/modules/xml.h
+++ b/include/parasol/modules/xml.h
@@ -10,6 +10,7 @@
 
 #ifdef __cplusplus
 #include <functional>
+#include <memory>
 #include <sstream>
 #ifndef STRINGS_HPP
 #include <parasol/strings.hpp>
@@ -18,6 +19,11 @@
 #endif
 
 class objXML;
+
+namespace xml::schema
+{
+   struct SchemaContext;
+}
 
 // For SetAttrib()
 
@@ -184,6 +190,9 @@ struct ResolvePrefix { CSTRING Prefix; int TagID; uint32_t Result; static const 
 struct SetVariable { CSTRING Key; CSTRING Value; static const AC id = AC(-23); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetEntity { CSTRING Name; CSTRING Value; static const AC id = AC(-24); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 struct GetNotation { CSTRING Name; CSTRING Value; static const AC id = AC(-25); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct LoadSchema { CSTRING Path; static const AC id = AC(-26); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct ValidateDocument { int Result; static const AC id = AC(-27); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
+struct HasSchema { int Result; static const AC id = AC(-28); ERR call(OBJECTPTR Object) { return Action(id, Object, this); } };
 
 } // namespace
 
@@ -208,6 +217,7 @@ class objXML : public Object {
    typedef pf::vector<XMLTag> TAGS;
    typedef pf::vector<XMLTag>::iterator CURSOR;
    TAGS Tags;
+   std::shared_ptr<xml::schema::SchemaContext> schema_context;
 
    template <class T> inline ERR insertStatement(int Index, XMI Where, T Statement, XMLTag **Result) {
       int index_result;
@@ -367,6 +377,22 @@ class objXML : public Object {
       struct xml::GetNotation args = { Name, (CSTRING)0 };
       ERR error = Action(AC(-25), this, &args);
       if (Value) *Value = args.Value;
+      return(error);
+   }
+   inline ERR loadSchema(CSTRING Path) noexcept {
+      struct xml::LoadSchema args = { Path };
+      return(Action(AC(-26), this, &args));
+   }
+   inline ERR validateDocument(int * Result) noexcept {
+      struct xml::ValidateDocument args = { 0 };
+      ERR error = Action(AC(-27), this, &args);
+      if (Result) *Result = args.Result;
+      return(error);
+   }
+   inline ERR hasSchema(int * Result) noexcept {
+      struct xml::HasSchema args = { 0 };
+      ERR error = Action(AC(-28), this, &args);
+      if (Result) *Result = args.Result;
       return(error);
    }
 

--- a/src/xml/CMakeLists.txt
+++ b/src/xml/CMakeLists.txt
@@ -44,6 +44,7 @@ flute_test (${MOD}_xpath_string_uri "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpat
 flute_test (${MOD}_xpath2_duration "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath2_duration.fluid")
 flute_test (${MOD}_xpath2_datetime "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath2_datetime.fluid")
 flute_test (${MOD}_xpath2_qname "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_xpath2_qname.fluid")
+flute_test (${MOD}_schema_validation "${CMAKE_CURRENT_SOURCE_DIR}/tests/test_schema_validation.fluid")
 
 if (INSTALL_TESTS)
    add_executable (test_xml_count_debug "tests/test_count_debug.cpp")

--- a/src/xml/schema/schema_parser.cpp
+++ b/src/xml/schema/schema_parser.cpp
@@ -1,18 +1,12 @@
 #include "schema_parser.h"
 
+#include <cstdlib>
 #include <parasol/strings.hpp>
 
 namespace xml::schema
 {
    namespace
    {
-      std::string_view extract_local_name(std::string_view Qualified) noexcept
-      {
-         auto colon = Qualified.find(':');
-         if (colon != std::string::npos) return Qualified.substr(colon + 1u);
-         return Qualified;
-      }
-
       bool is_named(std::string_view Name, std::string_view Expected)
       {
          return pf::iequals(std::string(Name), std::string(Expected));
@@ -27,19 +21,112 @@ namespace xml::schema
          result.append(Local);
          return result;
       }
+
+      std::string find_attribute_value(const XMLTag &Node, std::string_view Name)
+      {
+         for (size_t index = 1u; index < Node.Attribs.size(); ++index) {
+            const auto &Attrib = Node.Attribs[index];
+            if (pf::iequals(Attrib.Name, std::string(Name))) return Attrib.Value;
+         }
+         return std::string();
+      }
+
+      size_t parse_occurs_value(const std::string &Value, size_t DefaultValue, bool AllowUnbounded)
+      {
+         if (Value.empty()) return DefaultValue;
+         if (AllowUnbounded and pf::iequals(Value, "unbounded")) return std::numeric_limits<size_t>::max();
+
+         char *end = nullptr;
+         auto parsed = std::strtoull(Value.c_str(), &end, 10);
+         if ((end) and (*end IS '\0')) return static_cast<size_t>(parsed);
+         return DefaultValue;
+      }
+
+      void register_element_aliases(SchemaDocument &Document, const std::shared_ptr<ElementDescriptor> &Descriptor)
+      {
+         if (!Descriptor) return;
+         if (!Document.context) Document.context = std::make_shared<SchemaContext>();
+
+         auto &elements = Document.context->elements;
+         elements[Descriptor->name] = Descriptor;
+         if (!Descriptor->qualified_name.empty()) elements[Descriptor->qualified_name] = Descriptor;
+
+         auto local_name = std::string(extract_local_name(Descriptor->qualified_name.empty() ? Descriptor->name
+                                                                                               : Descriptor->qualified_name));
+         if (!local_name.empty()) elements[local_name] = Descriptor;
+
+         if (!Document.target_namespace_prefix.empty()) {
+            elements[make_qualified_name(Document.target_namespace_prefix, local_name)] = Descriptor;
+         }
+
+         for (const auto &entry : Document.namespace_bindings) {
+            if (entry.second IS Document.target_namespace) {
+               if (entry.first.empty()) elements[local_name] = Descriptor;
+               else elements[make_qualified_name(entry.first, local_name)] = Descriptor;
+            }
+         }
+      }
+   }
+
+   SchemaDocument::SchemaDocument()
+      : context(std::make_shared<SchemaContext>())
+   {
+   }
+
+   void SchemaDocument::merge_types()
+   {
+      if (!context) context = std::make_shared<SchemaContext>();
+
+      for (const auto &Descriptor : declared_types) {
+         if (!Descriptor) continue;
+
+         auto &types = context->types;
+         types[Descriptor->type_name] = Descriptor;
+
+         auto local_name = std::string(extract_local_name(Descriptor->type_name));
+         if (!local_name.empty()) types[local_name] = Descriptor;
+
+         if (!target_namespace_prefix.empty()) {
+            types[make_qualified_name(target_namespace_prefix, local_name)] = Descriptor;
+         }
+
+         for (const auto &entry : namespace_bindings) {
+            if (entry.second IS target_namespace) {
+               if (entry.first.empty()) types[local_name] = Descriptor;
+               else types[make_qualified_name(entry.first, local_name)] = Descriptor;
+            }
+         }
+      }
    }
 
    void SchemaDocument::clear()
    {
+      if (context) {
+         context->target_namespace.clear();
+         context->schema_prefix.clear();
+         context->target_namespace_prefix.clear();
+         context->namespace_bindings.clear();
+         context->types.clear();
+         context->complex_types.clear();
+         context->elements.clear();
+      }
+
       target_namespace.clear();
       schema_prefix.clear();
+      target_namespace_prefix.clear();
       namespace_bindings.clear();
       declared_types.clear();
    }
 
    bool SchemaDocument::empty() const noexcept
    {
-      return declared_types.empty() and target_namespace.empty();
+      if (!context) return true;
+      return declared_types.empty() and context->elements.empty() and context->complex_types.empty();
+   }
+
+   SchemaParser::SchemaParser(SchemaTypeRegistry &Registry)
+      : registry_ref(&Registry)
+   {
    }
 
    SchemaDocument SchemaParser::parse(const objXML::TAGS &Tags) const
@@ -53,6 +140,7 @@ namespace xml::schema
    {
       SchemaDocument Document;
       if (Root.Attribs.empty()) return Document;
+      if (!Document.context) Document.context = std::make_shared<SchemaContext>();
 
       std::string_view root_name(Root.Attribs[0].Name);
       auto colon = root_name.find(':');
@@ -73,12 +161,26 @@ namespace xml::schema
                prefix.assign(attrib_name.begin() + 6u, attrib_name.end());
             }
             Document.namespace_bindings[prefix] = Attrib.Value;
+            if ((Document.target_namespace_prefix.empty()) and (Attrib.Value IS Document.target_namespace)) {
+               Document.target_namespace_prefix = prefix;
+            }
          }
       }
 
-      auto AnyType = registry().find_descriptor(SchemaType::XSAnyType);
-      if (!AnyType) {
-         AnyType = registry().register_descriptor(SchemaType::XSAnyType, "xs:anyType", nullptr, true);
+      if (Document.target_namespace_prefix.empty()) {
+         for (const auto &entry : Document.namespace_bindings) {
+            if (entry.second IS Document.target_namespace) {
+               Document.target_namespace_prefix = entry.first;
+               break;
+            }
+         }
+      }
+
+      if (Document.context) {
+         Document.context->target_namespace = Document.target_namespace;
+         Document.context->schema_prefix = Document.schema_prefix;
+         Document.context->target_namespace_prefix = Document.target_namespace_prefix;
+         Document.context->namespace_bindings = Document.namespace_bindings;
       }
 
       for (const auto &Child : Root.Children) {
@@ -86,25 +188,164 @@ namespace xml::schema
 
          std::string_view child_name(Child.Attribs[0].Name);
          auto local_name = extract_local_name(child_name);
-         if ((!is_named(local_name, "simpleType")) and (!is_named(local_name, "complexType"))) continue;
 
-         std::string declared_name;
-         for (size_t attr_index = 1u; attr_index < Child.Attribs.size(); ++attr_index) {
-            const auto &ChildAttrib = Child.Attribs[attr_index];
-            if (pf::iequals(ChildAttrib.Name, "name")) {
-               declared_name = ChildAttrib.Value;
-               break;
-            }
+         if (is_named(local_name, "simpleType")) {
+            parse_simple_type(Child, Document);
+            continue;
          }
 
-         if (declared_name.empty()) continue;
+         if (is_named(local_name, "complexType")) {
+            parse_complex_type(Child, Document);
+            continue;
+         }
 
-         auto Descriptor = std::make_shared<SchemaTypeDescriptor>(SchemaType::UserDefined,
-                                                                  make_qualified_name(Document.schema_prefix, declared_name),
-                                                                  AnyType, false);
-         Document.declared_types.push_back(Descriptor);
+         if (is_named(local_name, "element")) {
+            parse_element(Child, Document);
+         }
       }
 
+      Document.merge_types();
       return Document;
+   }
+
+   std::shared_ptr<SchemaContext> SchemaParser::parse_context(const XMLTag &Root) const
+   {
+      auto Document = parse(Root);
+      return Document.context;
+   }
+
+   void SchemaParser::parse_simple_type(const XMLTag &Node, SchemaDocument &Document) const
+   {
+      auto declared_name = find_attribute_value(Node, "name");
+      if (declared_name.empty()) return;
+
+      std::string base_name;
+      for (const auto &Child : Node.Children) {
+         if (Child.Attribs.empty()) continue;
+         auto child_local = extract_local_name(Child.Attribs[0].Name);
+         if (!is_named(child_local, "restriction")) continue;
+
+         base_name = find_attribute_value(Child, "base");
+         break;
+      }
+
+      auto BaseDescriptor = resolve_type(base_name, Document);
+      if (!BaseDescriptor) BaseDescriptor = registry_ref->find_descriptor(SchemaType::XSAnyType);
+
+      auto qualified_name = Document.target_namespace_prefix.empty()
+         ? declared_name
+         : make_qualified_name(Document.target_namespace_prefix, declared_name);
+
+      auto Descriptor = std::make_shared<SchemaTypeDescriptor>(SchemaType::UserDefined, qualified_name, BaseDescriptor, false);
+      Document.declared_types.push_back(Descriptor);
+
+      auto &types = Document.context->types;
+      types[qualified_name] = Descriptor;
+      types[declared_name] = Descriptor;
+   }
+
+   void SchemaParser::parse_complex_type(const XMLTag &Node, SchemaDocument &Document) const
+   {
+      auto declared_name = find_attribute_value(Node, "name");
+      if (declared_name.empty()) return;
+
+      auto Descriptor = std::make_shared<ElementDescriptor>();
+      Descriptor->name = declared_name;
+      Descriptor->qualified_name = Document.target_namespace_prefix.empty()
+         ? declared_name
+         : make_qualified_name(Document.target_namespace_prefix, declared_name);
+
+      for (const auto &Child : Node.Children) {
+         if (Child.Attribs.empty()) continue;
+
+         auto child_local = extract_local_name(Child.Attribs[0].Name);
+         if (!is_named(child_local, "sequence")) continue;
+
+         for (const auto &SequenceChild : Child.Children) {
+            if (SequenceChild.Attribs.empty()) continue;
+            auto seq_local = extract_local_name(SequenceChild.Attribs[0].Name);
+            if (!is_named(seq_local, "element")) continue;
+
+            auto element_name = find_attribute_value(SequenceChild, "name");
+            if (element_name.empty()) continue;
+
+            auto element_descriptor = std::make_shared<ElementDescriptor>();
+            element_descriptor->name = element_name;
+            element_descriptor->qualified_name = Document.target_namespace_prefix.empty()
+               ? element_name
+               : make_qualified_name(Document.target_namespace_prefix, element_name);
+
+            auto type_name = find_attribute_value(SequenceChild, "type");
+            element_descriptor->type_name = type_name;
+            if (!type_name.empty()) element_descriptor->type = resolve_type(type_name, Document);
+
+            element_descriptor->min_occurs = parse_occurs_value(find_attribute_value(SequenceChild, "minOccurs"), 1u, false);
+            element_descriptor->max_occurs = parse_occurs_value(find_attribute_value(SequenceChild, "maxOccurs"), 1u, true);
+
+            Descriptor->children.push_back(element_descriptor);
+         }
+      }
+
+      Document.context->complex_types[Descriptor->name] = Descriptor;
+      Document.context->complex_types[Descriptor->qualified_name] = Descriptor;
+   }
+
+   void SchemaParser::parse_element(const XMLTag &Node, SchemaDocument &Document) const
+   {
+      auto declared_name = find_attribute_value(Node, "name");
+      if (declared_name.empty()) return;
+
+      auto Descriptor = std::make_shared<ElementDescriptor>();
+      Descriptor->name = declared_name;
+      Descriptor->qualified_name = Document.target_namespace_prefix.empty()
+         ? declared_name
+         : make_qualified_name(Document.target_namespace_prefix, declared_name);
+
+      auto type_name = find_attribute_value(Node, "type");
+      Descriptor->type_name = type_name;
+
+      if (!type_name.empty()) {
+         Descriptor->type = resolve_type(type_name, Document);
+
+         auto complex_it = Document.context->complex_types.find(type_name);
+         if (complex_it != Document.context->complex_types.end()) Descriptor->children = complex_it->second->children;
+         else {
+            auto local_name = std::string(extract_local_name(type_name));
+            complex_it = Document.context->complex_types.find(local_name);
+            if (complex_it != Document.context->complex_types.end()) Descriptor->children = complex_it->second->children;
+         }
+      }
+
+      register_element_aliases(Document, Descriptor);
+   }
+
+   std::shared_ptr<SchemaTypeDescriptor> SchemaParser::resolve_type(std::string_view Name, SchemaDocument &Document) const
+   {
+      if (!registry_ref) registry_ref = &registry();
+      if (Name.empty()) return registry_ref->find_descriptor(SchemaType::XSAnyType);
+
+      auto lookup_name = std::string(Name);
+      auto &types = Document.context->types;
+      auto iter = types.find(lookup_name);
+      if (iter != types.end()) return iter->second;
+
+      auto descriptor = registry_ref->find_descriptor(Name);
+      if (descriptor) return descriptor;
+
+      auto local_name = std::string(extract_local_name(Name));
+      iter = types.find(local_name);
+      if (iter != types.end()) return iter->second;
+
+      descriptor = registry_ref->find_descriptor(local_name);
+      if (descriptor) return descriptor;
+
+      return registry_ref->find_descriptor(SchemaType::XSAnyType);
+   }
+
+   std::string_view extract_local_name(std::string_view Qualified) noexcept
+   {
+      auto colon = Qualified.find(':');
+      if (colon != std::string::npos) return Qualified.substr(colon + 1u);
+      return Qualified;
    }
 }

--- a/src/xml/schema/schema_parser.cpp
+++ b/src/xml/schema/schema_parser.cpp
@@ -1,5 +1,5 @@
-#include "schema_parser.h"
 
+#include "schema_parser.h"
 #include <cstdlib>
 #include <parasol/strings.hpp>
 

--- a/src/xml/schema/schema_parser.h
+++ b/src/xml/schema/schema_parser.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ankerl/unordered_dense.h>
+#include <limits>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -9,12 +11,40 @@
 
 namespace xml::schema
 {
-   struct SchemaDocument
+   struct ElementDescriptor
+   {
+      std::string name;
+      std::string qualified_name;
+      std::string type_name;
+      std::shared_ptr<SchemaTypeDescriptor> type;
+      size_t min_occurs = 1u;
+      size_t max_occurs = std::numeric_limits<size_t>::max();
+      std::vector<std::shared_ptr<ElementDescriptor>> children;
+   };
+
+   struct SchemaContext
    {
       std::string target_namespace;
       std::string schema_prefix;
+      std::string target_namespace_prefix;
+      ankerl::unordered_dense::map<std::string, std::string> namespace_bindings;
+      ankerl::unordered_dense::map<std::string, std::shared_ptr<SchemaTypeDescriptor>> types;
+      ankerl::unordered_dense::map<std::string, std::shared_ptr<ElementDescriptor>> complex_types;
+      ankerl::unordered_dense::map<std::string, std::shared_ptr<ElementDescriptor>> elements;
+   };
+
+   struct SchemaDocument
+   {
+      SchemaDocument();
+
+      std::shared_ptr<SchemaContext> context;
+      std::string target_namespace;
+      std::string schema_prefix;
+      std::string target_namespace_prefix;
       ankerl::unordered_dense::map<std::string, std::string> namespace_bindings;
       std::vector<std::shared_ptr<SchemaTypeDescriptor>> declared_types;
+
+      void merge_types();
 
       void clear();
       [[nodiscard]] bool empty() const noexcept;
@@ -23,9 +53,21 @@ namespace xml::schema
    class SchemaParser
    {
       public:
-      SchemaParser() = default;
+      explicit SchemaParser(SchemaTypeRegistry &Registry);
 
       [[nodiscard]] SchemaDocument parse(const objXML::TAGS &Tags) const;
       [[nodiscard]] SchemaDocument parse(const XMLTag &Root) const;
+      [[nodiscard]] std::shared_ptr<SchemaContext> parse_context(const XMLTag &Root) const;
+
+      private:
+      SchemaTypeRegistry * registry_ref;
+
+      void parse_simple_type(const XMLTag &Node, SchemaDocument &Document) const;
+      void parse_complex_type(const XMLTag &Node, SchemaDocument &Document) const;
+      void parse_element(const XMLTag &Node, SchemaDocument &Document) const;
+      [[nodiscard]] std::shared_ptr<SchemaTypeDescriptor> resolve_type(std::string_view Name,
+                                                                       SchemaDocument &Document) const;
    };
+
+   [[nodiscard]] std::string_view extract_local_name(std::string_view Qualified) noexcept;
 }

--- a/src/xml/schema/schema_parser.h
+++ b/src/xml/schema/schema_parser.h
@@ -65,6 +65,10 @@ namespace xml::schema
       void parse_simple_type(const XMLTag &Node, SchemaDocument &Document) const;
       void parse_complex_type(const XMLTag &Node, SchemaDocument &Document) const;
       void parse_element(const XMLTag &Node, SchemaDocument &Document) const;
+      void parse_inline_complex_type(const XMLTag &Node, SchemaDocument &Document, ElementDescriptor &Descriptor) const;
+      void parse_sequence(const XMLTag &Node, SchemaDocument &Document, ElementDescriptor &Descriptor) const;
+      [[nodiscard]] std::shared_ptr<ElementDescriptor> parse_child_element_descriptor(const XMLTag &Node,
+                                                                                      SchemaDocument &Document) const;
       [[nodiscard]] std::shared_ptr<SchemaTypeDescriptor> resolve_type(std::string_view Name,
                                                                        SchemaDocument &Document) const;
    };

--- a/src/xml/schema/schema_types.cpp
+++ b/src/xml/schema/schema_types.cpp
@@ -1,6 +1,6 @@
+
 #include "schema_types.h"
 #include "../xml.h"
-
 #include <utility>
 
 namespace xml::schema

--- a/src/xml/schema/schema_types.h
+++ b/src/xml/schema/schema_types.h
@@ -5,9 +5,7 @@
 #include <string_view>
 #include <vector>
 #include <ankerl/unordered_dense.h>
-
 #include <parasol/modules/xml.h>
-
 #include "../xpath/xpath_functions.h"
 
 namespace xml::schema

--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -1,5 +1,5 @@
-#include "type_checker.h"
 
+#include "type_checker.h"
 #include <cmath>
 #include <limits>
 

--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -1,14 +1,69 @@
 #include "type_checker.h"
 
+#include <cmath>
+#include <limits>
+
 namespace xml::schema
 {
-   TypeChecker::TypeChecker(SchemaTypeRegistry &Registry)
-      : registry_ref(&Registry)
+   namespace
    {
+      const SchemaTypeDescriptor * resolve_effective_descriptor(const SchemaTypeDescriptor &Descriptor)
+      {
+         const SchemaTypeDescriptor *current = &Descriptor;
+         while (current and (current->schema_type IS SchemaType::UserDefined)) {
+            auto base = current->base();
+            if (!base) break;
+            current = base.get();
+         }
+         return current ? current : &Descriptor;
+      }
+
+      bool is_valid_boolean(std::string_view Value)
+      {
+         if (pf::iequals(Value, "true")) return true;
+         if (pf::iequals(Value, "false")) return true;
+         if (Value.length() IS 1) {
+            char ch = Value[0];
+            return (ch IS '0') or (ch IS '1');
+         }
+         return false;
+      }
+   }
+
+   TypeChecker::TypeChecker(SchemaTypeRegistry &Registry, const SchemaContext *Context)
+      : registry_ref(&Registry), context_ref(Context)
+   {
+   }
+
+   void TypeChecker::set_context(const SchemaContext *Context)
+   {
+      context_ref = Context;
+   }
+
+   const SchemaContext * TypeChecker::schema_context() const
+   {
+      return context_ref;
    }
 
    bool TypeChecker::validate_value(const XPathValue &Value, const SchemaTypeDescriptor &Descriptor) const
    {
+      auto effective = resolve_effective_descriptor(Descriptor);
+      auto target_type = effective->schema_type;
+
+      if (is_numeric(target_type)) {
+         auto coerced = effective->coerce_value(Value, target_type);
+         return !std::isnan(coerced.to_number());
+      }
+
+      if ((target_type IS SchemaType::XPathBoolean) or (target_type IS SchemaType::XSBoolean)) {
+         if (Value.type IS XPathValueType::Boolean) return true;
+         auto string_value = Value.to_string();
+         return is_valid_boolean(string_value);
+      }
+
+      if ((target_type IS SchemaType::XPathString) or (target_type IS SchemaType::XSString)) return true;
+      if (target_type IS SchemaType::XPathNodeSet) return Value.type IS XPathValueType::NodeSet;
+
       auto SourceType = schema_type_for_xpath(Value.type);
       auto SourceDescriptor = registry().find_descriptor(SourceType);
       if (not SourceDescriptor) return false;
@@ -17,8 +72,8 @@ namespace xml::schema
 
    bool TypeChecker::validate_attribute(const XMLAttrib &Attribute, const SchemaTypeDescriptor &Descriptor) const
    {
-      (void)Attribute;
-      return Descriptor.can_coerce_to(SchemaType::XPathString) or (Descriptor.schema_type IS SchemaType::UserDefined);
+      XPathValue value(Attribute.Value);
+      return validate_value(value, Descriptor);
    }
 
    bool TypeChecker::validate_node(const XMLTag &Tag, const SchemaTypeDescriptor &Descriptor) const
@@ -29,6 +84,67 @@ namespace xml::schema
          return not Tag.Children.empty();
       }
       return Descriptor.can_coerce_to(SchemaType::XPathNodeSet);
+   }
+
+   bool TypeChecker::validate_element(const XMLTag &Tag, const ElementDescriptor &Descriptor) const
+   {
+      if (Descriptor.type) {
+         XPathValue value(Tag.getContent());
+         return validate_value(value, *Descriptor.type);
+      }
+
+      if (Descriptor.children.empty()) return true;
+
+      ankerl::unordered_dense::map<const ElementDescriptor *, size_t> counters;
+      ankerl::unordered_dense::map<std::string, const ElementDescriptor *> lookup;
+
+      for (const auto &child : Descriptor.children) {
+         if (!child) continue;
+         lookup[child->name] = child.get();
+         if (!child->qualified_name.empty()) lookup[child->qualified_name] = child.get();
+
+         auto local_name = std::string(extract_local_name(child->qualified_name.empty() ? child->name
+                                                                                        : child->qualified_name));
+         if (!local_name.empty()) lookup[local_name] = child.get();
+         counters[child.get()] = 0u;
+      }
+
+      for (const auto &Child : Tag.Children) {
+         if (Child.Attribs.empty()) continue;
+         if (Child.Attribs[0].isContent()) continue;
+
+         std::string_view child_name(Child.Attribs[0].Name);
+         const ElementDescriptor *rule = nullptr;
+
+         auto iter = lookup.find(std::string(child_name));
+         if (iter != lookup.end()) rule = iter->second;
+         else {
+            auto local_name = std::string(extract_local_name(child_name));
+            auto local_iter = lookup.find(local_name);
+            if (local_iter != lookup.end()) rule = local_iter->second;
+         }
+
+         if (!rule) continue;
+
+         counters[rule]++;
+
+         if (rule->type) {
+            XPathValue child_value(Child.getContent());
+            if (!validate_value(child_value, *rule->type)) return false;
+         }
+         else if (!rule->children.empty()) {
+            if (!validate_element(Child, *rule)) return false;
+         }
+      }
+
+      for (const auto &child : Descriptor.children) {
+         if (!child) continue;
+         size_t count = counters[child.get()];
+         if (count < child->min_occurs) return false;
+         if ((child->max_occurs != std::numeric_limits<size_t>::max()) and (count > child->max_occurs)) return false;
+      }
+
+      return true;
    }
 
    SchemaTypeRegistry & TypeChecker::registry() const

--- a/src/xml/schema/type_checker.h
+++ b/src/xml/schema/type_checker.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "schema_types.h"
+#include "schema_parser.h"
 
 namespace xml::schema
 {
@@ -8,13 +8,18 @@ namespace xml::schema
    {
       private:
       SchemaTypeRegistry * registry_ref;
+      const SchemaContext * context_ref;
 
       public:
-      explicit TypeChecker(SchemaTypeRegistry &Registry);
+      explicit TypeChecker(SchemaTypeRegistry &Registry, const SchemaContext *Context = nullptr);
+
+      void set_context(const SchemaContext *Context);
+      [[nodiscard]] const SchemaContext * schema_context() const;
 
       [[nodiscard]] bool validate_value(const XPathValue &Value, const SchemaTypeDescriptor &Descriptor) const;
       [[nodiscard]] bool validate_attribute(const XMLAttrib &Attribute, const SchemaTypeDescriptor &Descriptor) const;
       [[nodiscard]] bool validate_node(const XMLTag &Tag, const SchemaTypeDescriptor &Descriptor) const;
+      [[nodiscard]] bool validate_element(const XMLTag &Tag, const ElementDescriptor &Descriptor) const;
       [[nodiscard]] SchemaTypeRegistry & registry() const;
    };
 }

--- a/src/xml/tests/schema_inventory.xml
+++ b/src/xml/tests/schema_inventory.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inventory xmlns="http://example.com/inventory">
+   <item>
+      <name>Widget</name>
+      <price>19.99</price>
+   </item>
+   <item>
+      <name>Gadget</name>
+      <price>5.00</price>
+   </item>
+</inventory>

--- a/src/xml/tests/schema_inventory.xsd
+++ b/src/xml/tests/schema_inventory.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://example.com/inventory"
+           xmlns:inv="http://example.com/inventory"
+           elementFormDefault="qualified">
+   <xs:simpleType name="PriceType">
+      <xs:restriction base="xs:decimal"/>
+   </xs:simpleType>
+
+   <xs:complexType name="ItemType">
+      <xs:sequence>
+         <xs:element name="name" type="xs:string"/>
+         <xs:element name="price" type="inv:PriceType"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:element name="inventory">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="item" type="inv:ItemType" minOccurs="1" maxOccurs="unbounded"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+</xs:schema>

--- a/src/xml/tests/schema_inventory_invalid.xml
+++ b/src/xml/tests/schema_inventory_invalid.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inventory xmlns="http://example.com/inventory">
+   <item>
+      <name>Widget</name>
+   </item>
+</inventory>

--- a/src/xml/tests/test_schema_validation.fluid
+++ b/src/xml/tests/test_schema_validation.fluid
@@ -4,15 +4,12 @@ function testLoadSchema()
    local err = glXML.mtLoadSchema(glScriptFolder .. "schema_inventory.xsd")
    assert(err == ERR_Okay, "LoadSchema() failed: " .. mSys.GetErrorMsg(err))
 
-   local errHas, has = glXML.mtHasSchema()
-   assert(errHas == ERR_Okay, "HasSchema() returned error: " .. mSys.GetErrorMsg(errHas))
-   assert(has == 1, "Schema not detected after loading")
+   assert(bit.band(glXML.flags, XMF_HAS_SCHEMA) != 0, "XMF_HAS_SCHEMA undefined")
 end
 
 function testValidateDocumentPass()
-   local err, result = glXML.mtValidateDocument()
+   local err = glXML.mtValidateDocument()
    assert(err == ERR_Okay, "ValidateDocument() returned error: " .. mSys.GetErrorMsg(err))
-   assert(result == 1, "Expected document to validate successfully")
 end
 
 function testValidateDocumentFail()
@@ -20,9 +17,8 @@ function testValidateDocumentFail()
    local err = invalid.mtLoadSchema(glScriptFolder .. "schema_inventory.xsd")
    assert(err == ERR_Okay, "Failed to load schema for invalid document: " .. mSys.GetErrorMsg(err))
 
-   local errValidate, result = invalid.mtValidateDocument()
-   assert(errValidate == ERR_Okay, "ValidateDocument() returned error: " .. mSys.GetErrorMsg(errValidate))
-   assert(result == 0, "Expected invalid document to fail validation")
+   local err = invalid.mtValidateDocument()
+   assert(err != ERR_Okay, "ValidateDocument() returned error: " .. mSys.GetErrorMsg(err))
 end
 
 return {

--- a/src/xml/tests/test_schema_validation.fluid
+++ b/src/xml/tests/test_schema_validation.fluid
@@ -1,0 +1,38 @@
+-- Schema validation tests for XML module
+
+function testLoadSchema()
+   local err = glXML.mtLoadSchema(glScriptFolder .. "schema_inventory.xsd")
+   assert(err == ERR_Okay, "LoadSchema() failed: " .. mSys.GetErrorMsg(err))
+
+   local errHas, has = glXML.mtHasSchema()
+   assert(errHas == ERR_Okay, "HasSchema() returned error: " .. mSys.GetErrorMsg(errHas))
+   assert(has == 1, "Schema not detected after loading")
+end
+
+function testValidateDocumentPass()
+   local err, result = glXML.mtValidateDocument()
+   assert(err == ERR_Okay, "ValidateDocument() returned error: " .. mSys.GetErrorMsg(err))
+   assert(result == 1, "Expected document to validate successfully")
+end
+
+function testValidateDocumentFail()
+   local invalid = obj.new("xml", { path = glScriptFolder .. "schema_inventory_invalid.xml" })
+   local err = invalid.mtLoadSchema(glScriptFolder .. "schema_inventory.xsd")
+   assert(err == ERR_Okay, "Failed to load schema for invalid document: " .. mSys.GetErrorMsg(err))
+
+   local errValidate, result = invalid.mtValidateDocument()
+   assert(errValidate == ERR_Okay, "ValidateDocument() returned error: " .. mSys.GetErrorMsg(errValidate))
+   assert(result == 0, "Expected invalid document to fail validation")
+end
+
+return {
+   tests = { 'testLoadSchema', 'testValidateDocumentPass', 'testValidateDocumentFail' },
+   init = function(ScriptFolder)
+      glScriptFolder = ScriptFolder
+      glXML = obj.new("xml", { path = ScriptFolder .. "schema_inventory.xml" })
+   end,
+   cleanup = function()
+      glXML = nil
+      glScriptFolder = nil
+   end
+}

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -2064,7 +2064,10 @@ static ERR XML_ValidateDocument(extXML *Self, struct xml::ValidateDocument *Args
    if (not Args) return log.warning(ERR::NullArgs);
    if (!Self->schema_context) { Args->Result = 0; return log.warning(ERR::NoSupport); }
    if (Self->Tags.empty()) { Args->Result = 0; return log.warning(ERR::NoData); }
-   if (Self->Tags[0].Attribs.empty()) { Args->Result = 0; return log.warning(ERR::InvalidData); }
+   if ((Self->Tags[0].Attribs.size() IS 0) or (Self->Tags[0].Attribs[0].Name.empty())) {
+      Args->Result = 0;
+      return log.warning(ERR::InvalidData);
+   }
 
    auto &context = *Self->schema_context;
    auto find_descriptor = [&](std::string_view Name) -> std::shared_ptr<xml::schema::ElementDescriptor>

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -1994,9 +1994,8 @@ static ERR GET_Tags(extXML *Self, XMLTag **Values, int *Elements)
 -METHOD-
 LoadSchema: Load an XML Schema definition to enable schema-aware validation.
 
-This method parses an XML Schema document and attaches its schema context to the
-current XML object.  Once loaded, schema metadata is available for validation
-and XPath evaluation routines that utilise schema-aware behaviour.
+This method parses an XML Schema document and attaches its schema context to the current XML object.  Once loaded, 
+schema metadata is available for validation and XPath evaluation routines that utilise schema-aware behaviour.
 
 -INPUT-
 cstr Path: File system path to the XML Schema (XSD) document.
@@ -2004,9 +2003,8 @@ cstr Path: File system path to the XML Schema (XSD) document.
 -ERRORS-
 Okay: Schema was successfully loaded and parsed.
 NullArgs: The Path argument was not provided.
-AllocMemory: Memory allocation failed while preparing the schema loader.
-InvalidData: The schema document did not contain any parsable definitions.
-File: The schema file could not be opened.
+NoData: The schema document did not contain any parsable definitions.
+CreateObject: The file in Path could not be processed as XML content.
 
 *********************************************************************************************************************/
 
@@ -2016,47 +2014,26 @@ static ERR XML_LoadSchema(extXML *Self, struct xml::LoadSchema *Args)
 
    if ((not Args) or (not Args->Path)) return log.warning(ERR::NullArgs);
 
-   pf::Create<objXML> schema_holder(NF::UNTRACKED);
-   if (!schema_holder.ok()) return log.warning(schema_holder.error);
+   pf::Create<extXML> schema({ fl::Path(Args->Path), fl::Flags(XMF::WELL_FORMED | XMF::NAMESPACE_AWARE) });
+   if (schema.ok()) {
+      if (schema->Tags.empty()) return log.warning(ERR::NoData);
 
-   auto schema_document = (extXML *)*schema_holder;
-   *schema_holder = nullptr;
-   auto init_error = schema_document->init();
-   if (init_error != ERR::Okay) {
-      FreeResource(schema_document->UID);
-      *schema_holder = nullptr;
-      return log.warning(init_error);
+      xml::schema::SchemaParser parser(xml::schema::registry());
+      XMLTag *root_tag = nullptr;
+      for (auto &tag : schema->Tags) {
+         if ((tag.Flags & XTF::INSTRUCTION) IS XTF::NIL) { root_tag = &tag; break; }
+      }
+
+      if (!root_tag) return log.warning(ERR::InvalidData);
+
+      auto Document = parser.parse(*root_tag);
+      if (Document.empty() or (not Document.context)) return log.warning(ERR::NoData);
+
+      Self->Flags |= XMF::HAS_SCHEMA;
+      Self->SchemaContext = Document.context;
+      return ERR::Okay;
    }
-
-   struct SchemaGuard {
-      extXML *object;
-      ~SchemaGuard() { if (object) FreeResource(object->UID); }
-   } guard{schema_document};
-
-   schema_document->Path = pf::strclone(Args->Path);
-   if (not schema_document->Path) return log.warning(ERR::AllocMemory);
-   schema_document->Flags = XMF::WELL_FORMED | XMF::NAMESPACE_AWARE;
-
-   auto error = parse_source(schema_document);
-
-   if (schema_document->Path) { FreeResource(schema_document->Path); schema_document->Path = nullptr; }
-
-   if (error != ERR::Okay) return log.warning(error);
-   if (schema_document->Tags.empty()) return log.warning(ERR::InvalidData);
-
-   xml::schema::SchemaParser parser(xml::schema::registry());
-   XMLTag *root_tag = nullptr;
-   for (auto &tag : schema_document->Tags) {
-      if ((tag.Flags & XTF::INSTRUCTION) IS XTF::NIL) { root_tag = &tag; break; }
-   }
-
-   if (!root_tag) return log.warning(ERR::InvalidData);
-
-   auto Document = parser.parse(*root_tag);
-   if (Document.empty() or (not Document.context)) return log.warning(ERR::InvalidData);
-
-   Self->schema_context = Document.context;
-   return ERR::Okay;
+   else return log.warning(ERR::CreateObject);
 }
 
 /*********************************************************************************************************************
@@ -2068,9 +2045,6 @@ This method performs structural and simple type validation of the document using
 the loaded XML Schema.  The Result parameter returns `1` when the document
 conforms to the schema, otherwise `0`.
 
--INPUT-
-&int Result: Receives `1` on success or `0` when validation fails.
-
 -ERRORS-
 Okay: Validation completed successfully.
 NullArgs: The Result parameter was not supplied.
@@ -2080,20 +2054,19 @@ Search: The schema does not define the root element present in the document.
 
 *********************************************************************************************************************/
 
-static ERR XML_ValidateDocument(extXML *Self, struct xml::ValidateDocument *Args)
+static ERR XML_ValidateDocument(extXML *Self, void *Args)
 {
    pf::Log log;
 
-   if (not Args) return log.warning(ERR::NullArgs);
-   if (!Self->schema_context) { Args->Result = 0; return log.warning(ERR::NoSupport); }
-   if (Self->Tags.empty()) { Args->Result = 0; return log.warning(ERR::NoData); }
-   if ((Self->Tags[0].Attribs.size() IS 0) or (Self->Tags[0].Attribs[0].Name.empty())) {
-      Args->Result = 0;
+   if (not Self->SchemaContext) return log.warning(ERR::NoSupport);
+   if (Self->Tags.empty()) return log.warning(ERR::NoData);
+   if ((Self->Tags[0].Attribs.empty()) or (Self->Tags[0].Attribs[0].Name.empty())) {
       return log.warning(ERR::InvalidData);
    }
 
-   auto &context = *Self->schema_context;
-   auto find_descriptor = [&](std::string_view Name) -> std::shared_ptr<xml::schema::ElementDescriptor>
+   auto &context = *Self->SchemaContext;
+   auto find_descriptor = [&](std::string_view Name) -> 
+      std::shared_ptr<xml::schema::ElementDescriptor>
    {
       auto iter = context.elements.find(std::string(Name));
       if (iter != context.elements.end()) return iter->second;
@@ -2119,56 +2092,16 @@ static ERR XML_ValidateDocument(extXML *Self, struct xml::ValidateDocument *Args
    }
 
    if (!document_root) {
-      Args->Result = 0;
       return log.warning(ERR::InvalidData);
    }
 
    std::string_view root_name(document_root->Attribs[0].Name);
    auto descriptor = find_descriptor(root_name);
-   if (!descriptor) {
-      Args->Result = 0;
-      return log.warning(ERR::Search);
-   }
+   if (!descriptor) return log.warning(ERR::Search);
 
-   xml::schema::TypeChecker checker(xml::schema::registry(), Self->schema_context.get());
-   bool valid = checker.validate_element(*document_root, *descriptor);
-   Args->Result = valid ? 1 : 0;
-
-   if (!valid) {
-      Self->ErrorMsg = "Schema validation failed";
-   }
-   else {
-      Self->ErrorMsg.clear();
-   }
-
-   return ERR::Okay;
-}
-
-/*********************************************************************************************************************
-
--METHOD-
-HasSchema: Determine if a schema has been loaded for this XML object.
-
-Returns `1` when a schema is currently associated with the XML object, otherwise
-returns `0`.
-
--INPUT-
-&int Result: Receives the schema availability flag.
-
--ERRORS-
-Okay: The query completed successfully.
-NullArgs: The Result parameter was not supplied.
-
-*********************************************************************************************************************/
-
-static ERR XML_HasSchema(extXML *Self, struct xml::HasSchema *Args)
-{
-   pf::Log log;
-
-   if (not Args) return log.warning(ERR::NullArgs);
-
-   Args->Result = Self->schema_context ? 1 : 0;
-   return ERR::Okay;
+   xml::schema::TypeChecker checker(xml::schema::registry(), Self->SchemaContext.get());
+   if (checker.validate_element(*document_root, *descriptor)) return ERR::Okay;
+   else return ERR::InvalidData;
 }
 
 //********************************************************************************************************************

--- a/src/xml/xml.fdl
+++ b/src/xml/xml.fdl
@@ -29,6 +29,7 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
     "PARSE_ENTITY: Entity references in the DTD will be parsed automatically.",
     "OMIT_TAGS: Prevents tags from being output when the XML is serialised (output content only).",
     "NAMESPACE_AWARE: Enable namespace processing during parsing.",
+    "HAS_SCHEMA: Automatically defined when a schema has been loaded into the XML object.",
     { INCLUDE_SIBLINGS = "0x80000000: Include siblings when building an XML string (#GetXMLString() only)" })
 
   enum("XMI", { type="int", start=0, comment="Tag insertion options." },
@@ -142,8 +143,7 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
     { id=24, name="GetEntity" },
     { id=25, name="GetNotation" },
     { id=26, name="LoadSchema" },
-    { id=27, name="ValidateDocument" },
-    { id=28, name="HasSchema" }
+    { id=27, name="ValidateDocument" }
   })
 
   class("XML", { src="xml.cpp", output="xml_def.c" }, [[

--- a/src/xml/xml.fdl
+++ b/src/xml/xml.fdl
@@ -140,7 +140,10 @@ module({ name="XML", copyright="Paul Manias © 2001-2025", version=1.0, timestam
     { id=22, name="ResolvePrefix" },
     { id=23, name="SetVariable" },
     { id=24, name="GetEntity" },
-    { id=25, name="GetNotation" }
+    { id=25, name="GetNotation" },
+    { id=26, name="LoadSchema" },
+    { id=27, name="ValidateDocument" },
+    { id=28, name="HasSchema" }
   })
 
   class("XML", { src="xml.cpp", output="xml_def.c" }, [[

--- a/src/xml/xml.h
+++ b/src/xml/xml.h
@@ -13,6 +13,8 @@
 #include <optional>
 #include <ankerl/unordered_dense.h>
 
+#include "schema/schema_parser.h"
+
 constexpr std::array<uint64_t, 4> name_char_table = []() {
    std::array<uint64_t, 4> table{0, 0, 0, 0};
    auto set_bit = [&](unsigned int c) { table[c >> 6] |= (uint64_t{1} << (c & 63)); };
@@ -156,7 +158,8 @@ class extXML : public objXML {
    TAGS *CursorTags;    // Updated by findTag().  This is the tag array to which the Cursor reference belongs
    CURSOR Cursor;       // Resulting cursor position (tag) after a successful search.
    FUNCTION Callback;
-
+   
+   std::shared_ptr<xml::schema::SchemaContext> SchemaContext;
    ankerl::unordered_dense::map<std::string, std::string> Variables; // XPath variable references
    ankerl::unordered_dense::map<std::string, std::string> Entities; // For general entities
    ankerl::unordered_dense::map<std::string, std::string> ParameterEntities; // For parameter entities

--- a/src/xml/xml_def.c
+++ b/src/xml/xml_def.c
@@ -17,6 +17,7 @@ static const struct FieldDef clXMLFlags[] = {
    { "ParseEntity", 0x00001000 },
    { "OmitTags", 0x00002000 },
    { "NamespaceAware", 0x00004000 },
+   { "HasSchema", 0x00008000 },
    { "IncludeSiblings", (int)0x80000000 },
    { nullptr, 0 }
 };
@@ -44,8 +45,6 @@ FDEF maSetVariable[] = { { "Key", FD_STR }, { "Value", FD_STR }, { 0, 0 } };
 FDEF maGetEntity[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
 FDEF maGetNotation[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
 FDEF maLoadSchema[] = { { "Path", FD_STR }, { 0, 0 } };
-FDEF maValidateDocument[] = { { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
-FDEF maHasSchema[] = { { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clXMLMethods[] = {
    { AC(-1), (APTR)XML_SetAttrib, "SetAttrib", maSetAttrib, sizeof(struct xml::SetAttrib) },
@@ -71,8 +70,7 @@ static const struct MethodEntry clXMLMethods[] = {
    { AC(-24), (APTR)XML_GetEntity, "GetEntity", maGetEntity, sizeof(struct xml::GetEntity) },
    { AC(-25), (APTR)XML_GetNotation, "GetNotation", maGetNotation, sizeof(struct xml::GetNotation) },
    { AC(-26), (APTR)XML_LoadSchema, "LoadSchema", maLoadSchema, sizeof(struct xml::LoadSchema) },
-   { AC(-27), (APTR)XML_ValidateDocument, "ValidateDocument", maValidateDocument, sizeof(struct xml::ValidateDocument) },
-   { AC(-28), (APTR)XML_HasSchema, "HasSchema", maHasSchema, sizeof(struct xml::HasSchema) },
+   { AC(-27), (APTR)XML_ValidateDocument, "ValidateDocument", 0, 0 },
    { AC::NIL, 0, 0, 0, 0 }
 };
 
@@ -90,4 +88,4 @@ static const struct ActionArray clXMLActions[] = {
 };
 
 #undef MOD_IDL
-#define MOD_IDL "s.XMLAttrib:zsName,zsValue\ns.XMLTag:lID,lParentID,lLineNo,lFlags,ulNamespaceID,zeAttribs:XMLAttrib[],zeChildren:XMLTag[]\nc.XMF:INCLUDE_COMMENTS=0x2,INCLUDE_SIBLINGS=0x80000000,INCLUDE_WHITESPACE=0x100,INDENT=0x8,LOCK_REMOVE=0x10,LOG_ALL=0x800,NAMESPACE_AWARE=0x4000,NEW=0x40,NO_ESCAPE=0x80,OMIT_TAGS=0x2000,PARSE_ENTITY=0x1000,PARSE_HTML=0x200,READABLE=0x8,STRIP_CDATA=0x400,STRIP_CONTENT=0x4,STRIP_HEADERS=0x20,WELL_FORMED=0x1\nc.XMI:CHILD=0x1,CHILD_END=0x3,END=0x4,NEXT=0x2,PREV=0x0,PREVIOUS=0x0\nc.XMS:NEW=0xffffffff,UPDATE=0xfffffffd,UPDATE_ONLY=0xfffffffe\nc.XSF:CHECK_SORT=0x2,DESC=0x1\nc.XTF:CDATA=0x1,COMMENT=0x8,INSTRUCTION=0x2,NOTATION=0x4\n"
+#define MOD_IDL "s.XMLAttrib:zsName,zsValue\ns.XMLTag:lID,lParentID,lLineNo,lFlags,ulNamespaceID,zeAttribs:XMLAttrib[],zeChildren:XMLTag[]\nc.XMF:HAS_SCHEMA=0x8000,INCLUDE_COMMENTS=0x2,INCLUDE_SIBLINGS=0x80000000,INCLUDE_WHITESPACE=0x100,INDENT=0x8,LOCK_REMOVE=0x10,LOG_ALL=0x800,NAMESPACE_AWARE=0x4000,NEW=0x40,NO_ESCAPE=0x80,OMIT_TAGS=0x2000,PARSE_ENTITY=0x1000,PARSE_HTML=0x200,READABLE=0x8,STRIP_CDATA=0x400,STRIP_CONTENT=0x4,STRIP_HEADERS=0x20,WELL_FORMED=0x1\nc.XMI:CHILD=0x1,CHILD_END=0x3,END=0x4,NEXT=0x2,PREV=0x0,PREVIOUS=0x0\nc.XMS:NEW=0xffffffff,UPDATE=0xfffffffd,UPDATE_ONLY=0xfffffffe\nc.XSF:CHECK_SORT=0x2,DESC=0x1\nc.XTF:CDATA=0x1,COMMENT=0x8,INSTRUCTION=0x2,NOTATION=0x4\n"

--- a/src/xml/xml_def.c
+++ b/src/xml/xml_def.c
@@ -43,6 +43,9 @@ FDEF maResolvePrefix[] = { { "Prefix", FD_STR }, { "TagID", FD_INT }, { "Result"
 FDEF maSetVariable[] = { { "Key", FD_STR }, { "Value", FD_STR }, { 0, 0 } };
 FDEF maGetEntity[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
 FDEF maGetNotation[] = { { "Name", FD_STR }, { "Value", FD_STR|FD_RESULT }, { 0, 0 } };
+FDEF maLoadSchema[] = { { "Path", FD_STR }, { 0, 0 } };
+FDEF maValidateDocument[] = { { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
+FDEF maHasSchema[] = { { "Result", FD_INT|FD_RESULT }, { 0, 0 } };
 
 static const struct MethodEntry clXMLMethods[] = {
    { AC(-1), (APTR)XML_SetAttrib, "SetAttrib", maSetAttrib, sizeof(struct xml::SetAttrib) },
@@ -67,6 +70,9 @@ static const struct MethodEntry clXMLMethods[] = {
    { AC(-23), (APTR)XML_SetVariable, "SetVariable", maSetVariable, sizeof(struct xml::SetVariable) },
    { AC(-24), (APTR)XML_GetEntity, "GetEntity", maGetEntity, sizeof(struct xml::GetEntity) },
    { AC(-25), (APTR)XML_GetNotation, "GetNotation", maGetNotation, sizeof(struct xml::GetNotation) },
+   { AC(-26), (APTR)XML_LoadSchema, "LoadSchema", maLoadSchema, sizeof(struct xml::LoadSchema) },
+   { AC(-27), (APTR)XML_ValidateDocument, "ValidateDocument", maValidateDocument, sizeof(struct xml::ValidateDocument) },
+   { AC(-28), (APTR)XML_HasSchema, "HasSchema", maHasSchema, sizeof(struct xml::HasSchema) },
    { AC::NIL, 0, 0, 0, 0 }
 };
 


### PR DESCRIPTION
## Summary
- add schema context structures and parsing utilities for XML schema metadata
- extend the XML type checker with schema-aware value and element validation
- expose loadSchema/validateDocument APIs and add schema validation fixture tests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe74f4110832ea04a0aceab58d834