### PR TITLE
Fix XML schema validation workflow

### DIFF
--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -88,7 +88,7 @@ namespace xml::schema
 
    bool TypeChecker::validate_element(const XMLTag &Tag, const ElementDescriptor &Descriptor) const
    {
-      if (Descriptor.type) {
+      if (Descriptor.type and Descriptor.children.empty()) {
          XPathValue value(Tag.getContent());
          return validate_value(value, *Descriptor.type);
       }
@@ -128,7 +128,7 @@ namespace xml::schema
 
          counters[rule]++;
 
-         if (rule->type) {
+         if (rule->type and rule->children.empty()) {
             XPathValue child_value(Child.getContent());
             if (!validate_value(child_value, *rule->type)) return false;
          }


### PR DESCRIPTION
## Summary
- construct a temporary XML object through the object factory when loading schemas so parsing honours module initialisation
- skip XML processing instructions when selecting root elements for both schema parsing and document validation
- ensure complex types in the schema type checker recurse into child elements instead of only validating scalar content

## Testing
- ctest --build-config FastBuild --test-dir build/agents -L xml

------
https://chatgpt.com/codex/tasks/task_e_68dc4635e474832ea904b1c0dd1e72c5