### PR TITLE
Fail schema validation when encountering unknown child elements

### DIFF
--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -124,7 +124,7 @@ namespace xml::schema
             if (local_iter != lookup.end()) rule = local_iter->second;
          }
 
-         if (!rule) continue;
+         if (!rule) return false;
 
          counters[rule]++;
 


### PR DESCRIPTION
## Summary
- make schema validation fail when a child element does not match any schema rule instead of ignoring it

## Testing
- cmake -S . -B build/agents -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/agents -DRUN_ANYWHERE=TRUE -DPARASOL_STATIC=OFF -DBUILD_DEFS=ON -DDISABLE_AUDIO=ON -DDISABLE_X11=ON -DDISABLE_DISPLAY=ON -DDISABLE_FONT=ON
- cmake --build build/agents --config Release --target xml --parallel

------
https://chatgpt.com/codex/tasks/task_e_68dc687384d0832ebdb63a79e1ab74a7