### PR TITLE
Improve XML schema validation diagnostics

### DIFF
--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -138,7 +138,6 @@ namespace xml::schema
       else {
          message.append("Value does not match expected type ");
          message.append(Descriptor.type_name);
-         message.push_back('.');
       }
 
       assign_error(std::move(message));
@@ -181,7 +180,6 @@ namespace xml::schema
          else {
             message.append("Content does not match expected type ");
             message.append(Descriptor.type_name);
-            message.push_back('.');
          }
 
          assign_error(std::move(message));
@@ -220,12 +218,10 @@ namespace xml::schema
          }
 
          if (!rule) {
-            auto message = std::string("Element ");
+            std::string message("Element ");
             if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
             else message.append("(unnamed)");
-            message.append(" contains unexpected child element ");
-            message.append(std::string(child_name));
-            message.push_back('.');
+            message += " contains unexpected child element " + std::string(child_name);
             assign_error(std::move(message));
             return false;
          }
@@ -236,7 +232,7 @@ namespace xml::schema
             XPathValue child_value(Child.getContent());
             if (!validate_value(child_value, *rule->type)) {
                std::string previous_error(last_error_message);
-               auto message = std::string("Element ");
+               std::string message("Element ");
                if (!Child.Attribs.empty() and !Child.Attribs[0].Name.empty()) message.append(Child.Attribs[0].Name);
                else message.append("(unnamed)");
                message.append(": ");
@@ -245,7 +241,6 @@ namespace xml::schema
                else {
                   message.append("Content does not match expected type ");
                   message.append(rule->type->type_name);
-                  message.push_back('.');
                }
 
                assign_error(std::move(message));
@@ -261,26 +256,18 @@ namespace xml::schema
          if (!child) continue;
          size_t count = counters[child.get()];
          if (count < child->min_occurs) {
-            auto message = std::string("Element ");
+            std::string message("Element ");
             if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
             else message.append("(unnamed)");
-            message.append(" is missing required child element ");
-            message.append(child->name);
-            message.append(" (expected at least ");
-            message.append(std::to_string(child->min_occurs));
-            message.append(").");
+            message += " is missing required child element " + child->name + " (expected at least " + std::to_string(child->min_occurs) + ").";
             assign_error(std::move(message));
             return false;
          }
          if ((child->max_occurs != std::numeric_limits<size_t>::max()) and (count > child->max_occurs)) {
-            auto message = std::string("Element ");
+            std::string message("Element ");
             if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
             else message.append("(unnamed)");
-            message.append(" contains too many ");
-            message.append(child->name);
-            message.append(" elements (maximum allowed is ");
-            message.append(std::to_string(child->max_occurs));
-            message.append(").");
+            message += " contains too many " + child->name + " elements (maximum allowed is " + std::to_string(child->max_occurs) + ").";
             assign_error(std::move(message));
             return false;
          }

--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -30,8 +30,8 @@ namespace xml::schema
       }
    }
 
-   TypeChecker::TypeChecker(SchemaTypeRegistry &Registry, const SchemaContext *Context)
-      : registry_ref(&Registry), context_ref(Context)
+   TypeChecker::TypeChecker(SchemaTypeRegistry &Registry, const SchemaContext *Context, std::string *ErrorSink)
+      : registry_ref(&Registry), context_ref(Context), error_sink(ErrorSink)
    {
    }
 
@@ -40,9 +40,32 @@ namespace xml::schema
       context_ref = Context;
    }
 
+   void TypeChecker::set_error_sink(std::string *ErrorSink)
+   {
+      error_sink = ErrorSink;
+      if (error_sink and not last_error_message.empty()) *error_sink = last_error_message;
+   }
+
+   void TypeChecker::clear_error() const
+   {
+      last_error_message.clear();
+      if (error_sink) error_sink->clear();
+   }
+
    const SchemaContext * TypeChecker::schema_context() const
    {
       return context_ref;
+   }
+
+   const std::string & TypeChecker::last_error() const
+   {
+      return last_error_message;
+   }
+
+   void TypeChecker::assign_error(std::string Message) const
+   {
+      last_error_message.assign(std::move(Message));
+      if (error_sink) *error_sink = last_error_message;
    }
 
    bool TypeChecker::validate_value(const XPathValue &Value, const SchemaTypeDescriptor &Descriptor) const
@@ -52,28 +75,74 @@ namespace xml::schema
 
       if (is_numeric(target_type)) {
          auto coerced = effective->coerce_value(Value, target_type);
-         return !std::isnan(coerced.to_number());
+         if (!std::isnan(coerced.to_number())) return true;
+
+         auto message = std::string("Value '");
+         message.append(Value.to_string());
+         message.append("' is not valid for type ");
+         message.append(effective->type_name);
+         message.push_back('.');
+         assign_error(std::move(message));
+         return false;
       }
 
       if ((target_type IS SchemaType::XPathBoolean) or (target_type IS SchemaType::XSBoolean)) {
          if (Value.type IS XPathValueType::Boolean) return true;
          auto string_value = Value.to_string();
-         return is_valid_boolean(string_value);
+         if (is_valid_boolean(string_value)) return true;
+
+         auto message = std::string("Value '");
+         message.append(string_value);
+         message.append("' is not a recognised boolean value.");
+         assign_error(std::move(message));
+         return false;
       }
 
       if ((target_type IS SchemaType::XPathString) or (target_type IS SchemaType::XSString)) return true;
-      if (target_type IS SchemaType::XPathNodeSet) return Value.type IS XPathValueType::NodeSet;
+      if (target_type IS SchemaType::XPathNodeSet) {
+         if (Value.type IS XPathValueType::NodeSet) return true;
+         assign_error("Expected a node-set value.");
+         return false;
+      }
 
       auto SourceType = schema_type_for_xpath(Value.type);
       auto SourceDescriptor = registry().find_descriptor(SourceType);
-      if (not SourceDescriptor) return false;
-      return SourceDescriptor->can_coerce_to(Descriptor.schema_type);
+      if (not SourceDescriptor) {
+         assign_error("Unsupported value type for schema coercion.");
+         return false;
+      }
+
+      if (SourceDescriptor->can_coerce_to(Descriptor.schema_type)) return true;
+
+      auto message = std::string("Cannot coerce value of type ");
+      message.append(SourceDescriptor->type_name);
+      message.append(" to required type ");
+      message.append(Descriptor.type_name);
+      message.push_back('.');
+      assign_error(std::move(message));
+      return false;
    }
 
    bool TypeChecker::validate_attribute(const XMLAttrib &Attribute, const SchemaTypeDescriptor &Descriptor) const
    {
       XPathValue value(Attribute.Value);
-      return validate_value(value, Descriptor);
+      if (validate_value(value, Descriptor)) return true;
+
+      std::string previous_error(last_error_message);
+      auto message = std::string("Attribute ");
+      if (!Attribute.Name.empty()) message.append(Attribute.Name);
+      else message.append("(unnamed)");
+      message.append(": ");
+
+      if (!previous_error.empty()) message.append(previous_error);
+      else {
+         message.append("Value does not match expected type ");
+         message.append(Descriptor.type_name);
+         message.push_back('.');
+      }
+
+      assign_error(std::move(message));
+      return false;
    }
 
    bool TypeChecker::validate_node(const XMLTag &Tag, const SchemaTypeDescriptor &Descriptor) const
@@ -81,16 +150,42 @@ namespace xml::schema
       if (Descriptor.schema_type IS SchemaType::XPathNodeSet) return true;
       if (Descriptor.can_coerce_to(SchemaType::XPathString)) {
          if (Tag.hasContent()) return true;
-         return not Tag.Children.empty();
+         if (not Tag.Children.empty()) return true;
+
+         auto message = std::string("Element ");
+         if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
+         else message.append("(unnamed)");
+         message.append(" is missing required textual content.");
+         assign_error(std::move(message));
+         return false;
       }
-      return Descriptor.can_coerce_to(SchemaType::XPathNodeSet);
+      if (Descriptor.can_coerce_to(SchemaType::XPathNodeSet)) return true;
+
+      assign_error("Element does not satisfy required node constraints.");
+      return false;
    }
 
    bool TypeChecker::validate_element(const XMLTag &Tag, const ElementDescriptor &Descriptor) const
    {
       if (Descriptor.type and Descriptor.children.empty()) {
          XPathValue value(Tag.getContent());
-         return validate_value(value, *Descriptor.type);
+         if (validate_value(value, *Descriptor.type)) return true;
+
+         std::string previous_error(last_error_message);
+         auto message = std::string("Element ");
+         if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
+         else message.append("(unnamed)");
+         message.append(": ");
+
+         if (!previous_error.empty()) message.append(previous_error);
+         else {
+            message.append("Content does not match expected type ");
+            message.append(Descriptor.type_name);
+            message.push_back('.');
+         }
+
+         assign_error(std::move(message));
+         return false;
       }
 
       if (Descriptor.children.empty()) return true;
@@ -124,13 +219,38 @@ namespace xml::schema
             if (local_iter != lookup.end()) rule = local_iter->second;
          }
 
-         if (!rule) return false;
+         if (!rule) {
+            auto message = std::string("Element ");
+            if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
+            else message.append("(unnamed)");
+            message.append(" contains unexpected child element ");
+            message.append(std::string(child_name));
+            message.push_back('.');
+            assign_error(std::move(message));
+            return false;
+         }
 
          counters[rule]++;
 
          if (rule->type and rule->children.empty()) {
             XPathValue child_value(Child.getContent());
-            if (!validate_value(child_value, *rule->type)) return false;
+            if (!validate_value(child_value, *rule->type)) {
+               std::string previous_error(last_error_message);
+               auto message = std::string("Element ");
+               if (!Child.Attribs.empty() and !Child.Attribs[0].Name.empty()) message.append(Child.Attribs[0].Name);
+               else message.append("(unnamed)");
+               message.append(": ");
+
+               if (!previous_error.empty()) message.append(previous_error);
+               else {
+                  message.append("Content does not match expected type ");
+                  message.append(rule->type->type_name);
+                  message.push_back('.');
+               }
+
+               assign_error(std::move(message));
+               return false;
+            }
          }
          else if (!rule->children.empty()) {
             if (!validate_element(Child, *rule)) return false;
@@ -140,8 +260,30 @@ namespace xml::schema
       for (const auto &child : Descriptor.children) {
          if (!child) continue;
          size_t count = counters[child.get()];
-         if (count < child->min_occurs) return false;
-         if ((child->max_occurs != std::numeric_limits<size_t>::max()) and (count > child->max_occurs)) return false;
+         if (count < child->min_occurs) {
+            auto message = std::string("Element ");
+            if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
+            else message.append("(unnamed)");
+            message.append(" is missing required child element ");
+            message.append(child->name);
+            message.append(" (expected at least ");
+            message.append(std::to_string(child->min_occurs));
+            message.append(").");
+            assign_error(std::move(message));
+            return false;
+         }
+         if ((child->max_occurs != std::numeric_limits<size_t>::max()) and (count > child->max_occurs)) {
+            auto message = std::string("Element ");
+            if (!Tag.Attribs.empty() and !Tag.Attribs[0].Name.empty()) message.append(Tag.Attribs[0].Name);
+            else message.append("(unnamed)");
+            message.append(" contains too many ");
+            message.append(child->name);
+            message.append(" elements (maximum allowed is ");
+            message.append(std::to_string(child->max_occurs));
+            message.append(").");
+            assign_error(std::move(message));
+            return false;
+         }
       }
 
       return true;

--- a/src/xml/schema/type_checker.h
+++ b/src/xml/schema/type_checker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "schema_parser.h"
+#include <string>
 
 namespace xml::schema
 {
@@ -9,12 +10,20 @@ namespace xml::schema
       private:
       SchemaTypeRegistry * registry_ref;
       const SchemaContext * context_ref;
+      std::string * error_sink;
+      mutable std::string last_error_message;
+
+      void assign_error(std::string Message) const;
 
       public:
-      explicit TypeChecker(SchemaTypeRegistry &Registry, const SchemaContext *Context = nullptr);
+      explicit TypeChecker(SchemaTypeRegistry &Registry, const SchemaContext *Context = nullptr,
+                           std::string *ErrorSink = nullptr);
 
       void set_context(const SchemaContext *Context);
+      void set_error_sink(std::string *ErrorSink);
+      void clear_error() const;
       [[nodiscard]] const SchemaContext * schema_context() const;
+      [[nodiscard]] const std::string & last_error() const;
 
       [[nodiscard]] bool validate_value(const XPathValue &Value, const SchemaTypeDescriptor &Descriptor) const;
       [[nodiscard]] bool validate_attribute(const XMLAttrib &Attribute, const SchemaTypeDescriptor &Descriptor) const;

--- a/src/xml/tests/test_schema_validation.fluid
+++ b/src/xml/tests/test_schema_validation.fluid
@@ -1,5 +1,13 @@
 -- Schema validation tests for XML module
 
+glInvalidXML = [[<?xml version="1.0" encoding="UTF-8"?>
+<inventory xmlns="http://example.com/inventory">
+   <item>
+      <name>Widget</name>
+   </item>
+</inventory>
+]]
+
 function testLoadSchema()
    local err = glXML.mtLoadSchema(glScriptFolder .. "schema_inventory.xsd")
    assert(err == ERR_Okay, "LoadSchema() failed: " .. mSys.GetErrorMsg(err))
@@ -13,12 +21,14 @@ function testValidateDocumentPass()
 end
 
 function testValidateDocumentFail()
-   local invalid = obj.new("xml", { path = glScriptFolder .. "schema_inventory_invalid.xml" })
+   local invalid = obj.new("xml", { statement = glInvalidXML })
    local err = invalid.mtLoadSchema(glScriptFolder .. "schema_inventory.xsd")
    assert(err == ERR_Okay, "Failed to load schema for invalid document: " .. mSys.GetErrorMsg(err))
 
    local err = invalid.mtValidateDocument()
-   assert(err != ERR_Okay, "ValidateDocument() returned error: " .. mSys.GetErrorMsg(err))
+   assert(err != ERR_Okay, "ValidateDocument() returned Okay error code.")
+   assert(invalid.errorMsg != nil and invalid.errorMsg != "",
+      "ValidateDocument() did not populate errorMsg on failure.")
 end
 
 return {

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -2105,12 +2105,9 @@ static ERR XML_ValidateDocument(extXML *Self, void *Args)
       return log.warning(ERR::InvalidData);
    }
 
-   std::string_view root_name(document_root->Attribs[0].Name);
-   auto descriptor = find_descriptor(root_name);
+   auto descriptor = find_descriptor(document_root->Attribs[0].Name);
    if (!descriptor) {
-      Self->ErrorMsg = "Schema does not define root element '";
-      Self->ErrorMsg.append(root_name);
-      Self->ErrorMsg.append("'.");
+      Self->ErrorMsg = "Schema does not define root element '" + document_root->Attribs[0].Name + "'.";
       return log.warning(ERR::Search);
    }
 
@@ -2127,7 +2124,8 @@ static ERR XML_ValidateDocument(extXML *Self, void *Args)
       if (Self->ErrorMsg.empty()) Self->ErrorMsg = "Schema validation failed.";
    }
 
-   return log.warning(ERR::InvalidData);
+   log.warning("%s", Self->ErrorMsg.c_str());
+   return ERR::InvalidData;
 }
 
 //********************************************************************************************************************


### PR DESCRIPTION
## Summary
- extend the XML schema type checker so it records detailed error messages and can write them to a supplied sink
- surface validation diagnostics through `XML_ValidateDocument`, populating `extXML::ErrorMsg` before returning

## Testing
- `cmake --build build/agents --config FastBuild --target xml --parallel`


------
https://chatgpt.com/codex/tasks/task_e_68dc6b0d4f3c832e979fed19ce913722