### PR TITLE
Document XML schema utilities

### DIFF
--- a/src/xml/schema/schema_parser.h
+++ b/src/xml/schema/schema_parser.h
@@ -1,3 +1,5 @@
+// schema_parser.h - Declares structures and helpers for interpreting XML Schema documents.
+
 #pragma once
 
 #include <ankerl/unordered_dense.h>

--- a/src/xml/schema/schema_types.cpp
+++ b/src/xml/schema/schema_types.cpp
@@ -1,3 +1,4 @@
+// schema_types.cpp - Implements schema type descriptors and registry utilities for the XML module.
 
 #include "schema_types.h"
 #include "../xml.h"
@@ -7,12 +8,14 @@ namespace xml::schema
 {
    namespace
    {
+      // Creates a descriptor instance with the supplied metadata for registration.
       std::shared_ptr<SchemaTypeDescriptor> make_descriptor(SchemaType Type, std::string Name,
                                                             const std::shared_ptr<SchemaTypeDescriptor> &Base, bool Builtin)
       {
          return std::make_shared<SchemaTypeDescriptor>(Type, std::move(Name), Base, Builtin);
       }
 
+      // Tests whether the provided schema type represents a string-like value.
       bool is_schema_string(SchemaType Type) noexcept
       {
          switch (Type) {
@@ -24,6 +27,7 @@ namespace xml::schema
          }
       }
 
+      // Tests whether the provided schema type represents a numeric value category.
       bool is_schema_numeric(SchemaType Type) noexcept
       {
          switch (Type) {
@@ -59,6 +63,7 @@ namespace xml::schema
       return builtin_type;
    }
 
+   // Determines whether the descriptor ultimately derives from the requested schema type.
    bool SchemaTypeDescriptor::is_derived_from(SchemaType Target) const
    {
       if (schema_type IS Target) return true;
@@ -71,6 +76,7 @@ namespace xml::schema
       return false;
    }
 
+   // Reports whether the descriptor can legally coerce values into the requested type.
    bool SchemaTypeDescriptor::can_coerce_to(SchemaType Target) const
    {
       if (schema_type IS Target) return true;
@@ -86,6 +92,7 @@ namespace xml::schema
       return false;
    }
 
+   // Converts an XPath value into the requested schema type when permitted.
    XPathValue SchemaTypeDescriptor::coerce_value(const XPathValue &Value, SchemaType Target) const
    {
       if ((schema_type IS Target) or (Target IS SchemaType::XSAnyType)) return Value;
@@ -110,6 +117,7 @@ namespace xml::schema
       register_builtin_types();
    }
 
+   // Registers a descriptor for the given type if one does not already exist.
    std::shared_ptr<SchemaTypeDescriptor> SchemaTypeRegistry::register_descriptor(SchemaType Type, std::string Name,
                                                                                  std::shared_ptr<SchemaTypeDescriptor> Base,
                                                                                  bool Builtin)
@@ -143,6 +151,7 @@ namespace xml::schema
       descriptors_by_name.clear();
    }
 
+   // Populates the registry with the built-in schema types recognised by Parasol.
    void SchemaTypeRegistry::register_builtin_types()
    {
       clear();
@@ -186,6 +195,7 @@ namespace xml::schema
       return is_schema_string(Type);
    }
 
+   // Maps an XPath runtime value type onto the corresponding schema type.
    SchemaType schema_type_for_xpath(XPathValueType Type) noexcept
    {
       switch (Type) {

--- a/src/xml/schema/schema_types.h
+++ b/src/xml/schema/schema_types.h
@@ -1,3 +1,5 @@
+// schema_types.h - Declares schema type descriptors and registry helpers for XML validation.
+
 #pragma once
 
 #include <memory>

--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -1,3 +1,4 @@
+// type_checker.cpp - Implements schema-aware validation helpers for XML documents.
 
 #include "type_checker.h"
 #include <cmath>
@@ -7,6 +8,7 @@ namespace xml::schema
 {
    namespace
    {
+      // Follows user-defined types to find the underlying built-in descriptor.
       const SchemaTypeDescriptor * resolve_effective_descriptor(const SchemaTypeDescriptor &Descriptor)
       {
          const SchemaTypeDescriptor *current = &Descriptor;
@@ -18,6 +20,7 @@ namespace xml::schema
          return current ? current : &Descriptor;
       }
 
+      // Determines whether the supplied string value represents a valid boolean literal.
       bool is_valid_boolean(std::string_view Value)
       {
          if (pf::iequals(Value, "true")) return true;
@@ -68,6 +71,7 @@ namespace xml::schema
       if (error_sink) *error_sink = last_error_message;
    }
 
+   // Validates that the provided XPath value conforms to the supplied schema descriptor.
    bool TypeChecker::validate_value(const XPathValue &Value, const SchemaTypeDescriptor &Descriptor) const
    {
       auto effective = resolve_effective_descriptor(Descriptor);
@@ -123,6 +127,7 @@ namespace xml::schema
       return false;
    }
 
+   // Validates an attribute against the descriptor and records detailed errors when it fails.
    bool TypeChecker::validate_attribute(const XMLAttrib &Attribute, const SchemaTypeDescriptor &Descriptor) const
    {
       XPathValue value(Attribute.Value);
@@ -144,6 +149,7 @@ namespace xml::schema
       return false;
    }
 
+   // Validates that the tag node satisfies the structural requirements of the descriptor.
    bool TypeChecker::validate_node(const XMLTag &Tag, const SchemaTypeDescriptor &Descriptor) const
    {
       if (Descriptor.schema_type IS SchemaType::XPathNodeSet) return true;
@@ -164,6 +170,7 @@ namespace xml::schema
       return false;
    }
 
+   // Validates an element against the descriptor, recursively checking child elements as required.
    bool TypeChecker::validate_element(const XMLTag &Tag, const ElementDescriptor &Descriptor) const
    {
       if (Descriptor.type and Descriptor.children.empty()) {

--- a/src/xml/schema/type_checker.h
+++ b/src/xml/schema/type_checker.h
@@ -1,3 +1,5 @@
+// type_checker.h - Declares XML schema validation utilities for checking instance documents.
+
 #pragma once
 
 #include "schema_parser.h"


### PR DESCRIPTION
## Summary
- add descriptive file headers to the XML schema sources and headers
- annotate lengthy XML schema helper functions with one-line documentation comments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc732f18d0832ebc52c0dec4a9e13b