### PR TITLE
Clarify XML schema component documentation

### DIFF
--- a/src/xml/schema/schema_parser.cpp
+++ b/src/xml/schema/schema_parser.cpp
@@ -1,3 +1,8 @@
+// schema_parser.cpp - Implements the concrete reader that turns parsed XML Schema documents into
+// SchemaDocument and SchemaContext structures consumed throughout the XML module.  The routines in
+// this file walk the tag tree provided by objXML, extract namespace bindings, assemble element and
+// type descriptors, and wire the results into the shared registry so that downstream validation,
+// code generation, and tooling layers can reason about schema-constrained XML data.
 
 #include "schema_parser.h"
 #include <cstdlib>
@@ -22,6 +27,7 @@ namespace xml::schema
          return result;
       }
 
+      // Retrieves the value of the named attribute from the supplied node if present.
       std::string find_attribute_value(const XMLTag &Node, std::string_view Name)
       {
          for (size_t index = 1u; index < Node.Attribs.size(); ++index) {
@@ -31,6 +37,7 @@ namespace xml::schema
          return std::string();
       }
 
+      // Parses the min/max occurs value, supporting defaults and the unbounded keyword.
       size_t parse_occurs_value(const std::string &Value, size_t DefaultValue, bool AllowUnbounded)
       {
          if (Value.empty()) return DefaultValue;
@@ -42,6 +49,7 @@ namespace xml::schema
          return DefaultValue;
       }
 
+      // Registers multiple aliases for the supplied element descriptor within the schema context.
       void register_element_aliases(SchemaDocument &Document, const std::shared_ptr<ElementDescriptor> &Descriptor)
       {
          if (!Descriptor) return;
@@ -73,6 +81,7 @@ namespace xml::schema
    {
    }
 
+   // Populates the schema context with the type descriptors declared in the document.
    void SchemaDocument::merge_types()
    {
       if (!context) context = std::make_shared<SchemaContext>();
@@ -99,6 +108,7 @@ namespace xml::schema
       }
    }
 
+   // Resets the document and its context to an empty state ready for reuse.
    void SchemaDocument::clear()
    {
       if (context) {
@@ -136,6 +146,7 @@ namespace xml::schema
       return parse(Tags[0]);
    }
 
+   // Parses an XML schema root node into a schema document with context and descriptors.
    SchemaDocument SchemaParser::parse(const XMLTag &Root) const
    {
       SchemaDocument Document;
@@ -214,6 +225,7 @@ namespace xml::schema
       return Document.context;
    }
 
+   // Extracts a named simple type definition and records it against the document.
    void SchemaParser::parse_simple_type(const XMLTag &Node, SchemaDocument &Document) const
    {
       auto declared_name = find_attribute_value(Node, "name");
@@ -244,6 +256,7 @@ namespace xml::schema
       types[declared_name] = Descriptor;
    }
 
+   // Extracts a named complex type definition and stores its descriptor in the document context.
    void SchemaParser::parse_complex_type(const XMLTag &Node, SchemaDocument &Document) const
    {
       auto declared_name = find_attribute_value(Node, "name");
@@ -262,6 +275,7 @@ namespace xml::schema
       Document.context->complex_types[Descriptor->qualified_name] = Descriptor;
    }
 
+   // Parses a top-level element definition and resolves its associated type information.
    void SchemaParser::parse_element(const XMLTag &Node, SchemaDocument &Document) const
    {
       auto declared_name = find_attribute_value(Node, "name");
@@ -315,6 +329,7 @@ namespace xml::schema
       register_element_aliases(Document, Descriptor);
    }
 
+   // Processes inline complexType definitions embedded within other schema elements.
    void SchemaParser::parse_inline_complex_type(const XMLTag &Node, SchemaDocument &Document, ElementDescriptor &Descriptor) const
    {
       for (const auto &Child : Node.Children) {
@@ -346,6 +361,7 @@ namespace xml::schema
       }
    }
 
+   // Adds element descriptors defined within a sequence child of a complex type.
    void SchemaParser::parse_sequence(const XMLTag &Node, SchemaDocument &Document, ElementDescriptor &Descriptor) const
    {
       for (const auto &SequenceChild : Node.Children) {
@@ -361,6 +377,7 @@ namespace xml::schema
       }
    }
 
+   // Builds a descriptor for a child element, resolving occurrence constraints and type information.
    std::shared_ptr<ElementDescriptor> SchemaParser::parse_child_element_descriptor(const XMLTag &Node,
                                                                                    SchemaDocument &Document) const
    {
@@ -418,6 +435,7 @@ namespace xml::schema
       return element_descriptor;
    }
 
+   // Resolves the named schema type using the document context and registry fallbacks.
    std::shared_ptr<SchemaTypeDescriptor> SchemaParser::resolve_type(std::string_view Name, SchemaDocument &Document) const
    {
       if (Name.empty()) return registry_ref->find_descriptor(SchemaType::XSAnyType);

--- a/src/xml/schema/schema_parser.h
+++ b/src/xml/schema/schema_parser.h
@@ -1,3 +1,9 @@
+// schema_parser.h - Declares the SchemaDocument data model alongside the SchemaParser façade that
+// cooperatively translates XML Schema tag trees into reusable descriptors.  These declarations are
+// shared by the parser implementation, the schema-aware validator, and any tooling that needs to
+// inspect namespaces, complex element hierarchies, or named type definitions extracted from XSD
+// files.
+
 #pragma once
 
 #include <ankerl/unordered_dense.h>

--- a/src/xml/schema/schema_types.cpp
+++ b/src/xml/schema/schema_types.cpp
@@ -1,3 +1,8 @@
+// schema_types.cpp - Provides the backing logic for schema type descriptors and their registry,
+// modelling the primitive, derived, and user-defined datatypes referenced by XML Schema documents.
+// The functions here create descriptors, maintain inheritance relationships, and expose coercion
+// helpers so that other parts of the XML stack can interpret values in the context of XSD typing
+// rules.
 
 #include "schema_types.h"
 #include "../xml.h"
@@ -7,12 +12,14 @@ namespace xml::schema
 {
    namespace
    {
+      // Creates a descriptor instance with the supplied metadata for registration.
       std::shared_ptr<SchemaTypeDescriptor> make_descriptor(SchemaType Type, std::string Name,
                                                             const std::shared_ptr<SchemaTypeDescriptor> &Base, bool Builtin)
       {
          return std::make_shared<SchemaTypeDescriptor>(Type, std::move(Name), Base, Builtin);
       }
 
+      // Tests whether the provided schema type represents a string-like value.
       bool is_schema_string(SchemaType Type) noexcept
       {
          switch (Type) {
@@ -24,6 +31,7 @@ namespace xml::schema
          }
       }
 
+      // Tests whether the provided schema type represents a numeric value category.
       bool is_schema_numeric(SchemaType Type) noexcept
       {
          switch (Type) {
@@ -59,6 +67,7 @@ namespace xml::schema
       return builtin_type;
    }
 
+   // Determines whether the descriptor ultimately derives from the requested schema type.
    bool SchemaTypeDescriptor::is_derived_from(SchemaType Target) const
    {
       if (schema_type IS Target) return true;
@@ -71,6 +80,7 @@ namespace xml::schema
       return false;
    }
 
+   // Reports whether the descriptor can legally coerce values into the requested type.
    bool SchemaTypeDescriptor::can_coerce_to(SchemaType Target) const
    {
       if (schema_type IS Target) return true;
@@ -86,6 +96,7 @@ namespace xml::schema
       return false;
    }
 
+   // Converts an XPath value into the requested schema type when permitted.
    XPathValue SchemaTypeDescriptor::coerce_value(const XPathValue &Value, SchemaType Target) const
    {
       if ((schema_type IS Target) or (Target IS SchemaType::XSAnyType)) return Value;
@@ -110,6 +121,7 @@ namespace xml::schema
       register_builtin_types();
    }
 
+   // Registers a descriptor for the given type if one does not already exist.
    std::shared_ptr<SchemaTypeDescriptor> SchemaTypeRegistry::register_descriptor(SchemaType Type, std::string Name,
                                                                                  std::shared_ptr<SchemaTypeDescriptor> Base,
                                                                                  bool Builtin)
@@ -143,6 +155,7 @@ namespace xml::schema
       descriptors_by_name.clear();
    }
 
+   // Populates the registry with the built-in schema types recognised by Parasol.
    void SchemaTypeRegistry::register_builtin_types()
    {
       clear();
@@ -186,6 +199,7 @@ namespace xml::schema
       return is_schema_string(Type);
    }
 
+   // Maps an XPath runtime value type onto the corresponding schema type.
    SchemaType schema_type_for_xpath(XPathValueType Type) noexcept
    {
       switch (Type) {

--- a/src/xml/schema/schema_types.h
+++ b/src/xml/schema/schema_types.h
@@ -1,3 +1,8 @@
+// schema_types.h - Defines the SchemaType enumeration, descriptor classes, and registry interface
+// that capture XML Schema datatype semantics for the wider XML subsystem.  Consumers include the
+// schema parser, type checker, and XPath integration points that require quick lookup of built-in
+// and user-defined types, inheritance relationships, and value coercion behaviours.
+
 #pragma once
 
 #include <memory>

--- a/src/xml/schema/type_checker.cpp
+++ b/src/xml/schema/type_checker.cpp
@@ -1,3 +1,8 @@
+// type_checker.cpp - Contains the runtime validation engine that applies schema-derived type and
+// element descriptors to concrete XML instance data.  The implementation cross-references the
+// registry, performs value coercion checks, and surfaces detailed diagnostic messages so that
+// callers can enforce XSD constraints when loading or manipulating documents through Parasol's XML
+// facilities.
 
 #include "type_checker.h"
 #include <cmath>
@@ -7,6 +12,7 @@ namespace xml::schema
 {
    namespace
    {
+      // Follows user-defined types to find the underlying built-in descriptor.
       const SchemaTypeDescriptor * resolve_effective_descriptor(const SchemaTypeDescriptor &Descriptor)
       {
          const SchemaTypeDescriptor *current = &Descriptor;
@@ -18,6 +24,7 @@ namespace xml::schema
          return current ? current : &Descriptor;
       }
 
+      // Determines whether the supplied string value represents a valid boolean literal.
       bool is_valid_boolean(std::string_view Value)
       {
          if (pf::iequals(Value, "true")) return true;
@@ -68,6 +75,7 @@ namespace xml::schema
       if (error_sink) *error_sink = last_error_message;
    }
 
+   // Validates that the provided XPath value conforms to the supplied schema descriptor.
    bool TypeChecker::validate_value(const XPathValue &Value, const SchemaTypeDescriptor &Descriptor) const
    {
       auto effective = resolve_effective_descriptor(Descriptor);
@@ -123,6 +131,7 @@ namespace xml::schema
       return false;
    }
 
+   // Validates an attribute against the descriptor and records detailed errors when it fails.
    bool TypeChecker::validate_attribute(const XMLAttrib &Attribute, const SchemaTypeDescriptor &Descriptor) const
    {
       XPathValue value(Attribute.Value);
@@ -144,6 +153,7 @@ namespace xml::schema
       return false;
    }
 
+   // Validates that the tag node satisfies the structural requirements of the descriptor.
    bool TypeChecker::validate_node(const XMLTag &Tag, const SchemaTypeDescriptor &Descriptor) const
    {
       if (Descriptor.schema_type IS SchemaType::XPathNodeSet) return true;
@@ -164,6 +174,7 @@ namespace xml::schema
       return false;
    }
 
+   // Validates an element against the descriptor, recursively checking child elements as required.
    bool TypeChecker::validate_element(const XMLTag &Tag, const ElementDescriptor &Descriptor) const
    {
       if (Descriptor.type and Descriptor.children.empty()) {

--- a/src/xml/schema/type_checker.h
+++ b/src/xml/schema/type_checker.h
@@ -1,3 +1,8 @@
+// type_checker.h - Declares the TypeChecker façade used by callers to validate XML instance data
+// against schema-derived descriptors.  It exposes context wiring, error reporting, and per-value or
+// per-element verification entry points that integrate with the schema parser and type registry to
+// deliver comprehensive XSD enforcement inside the XML module.
+
 #pragma once
 
 #include "schema_parser.h"


### PR DESCRIPTION
## Summary
- expand the introductory comments across the XML schema parser, type registry, and validator sources
- document how each header is shared within the XML module to guide future maintenance

## Testing
- `cmake --build build/agents --config Release --target xml --parallel` *(fails: build tree not generated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc732f18d0832ebc52c0dec4a9e13b