### PR TITLE
Fix XML schema validation namespace detection

### DIFF
--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -2124,14 +2124,51 @@ static ERR XML_ValidateDocument(extXML *Self, void *Args)
    std::string root_namespace;
    bool root_has_namespace = false;
 
+   auto assign_root_namespace = [&](const std::string &value)
+   {
+      if (root_has_namespace) return;
+      if (value.empty()) return;
+
+      root_namespace = value;
+      root_has_namespace = true;
+   };
+
    if (document_root->NamespaceID != 0u) {
       if (auto uri = Self->getNamespaceURI(document_root->NamespaceID)) {
-         root_namespace = *uri;
-         root_has_namespace = true;
+         assign_root_namespace(*uri);
       }
       else {
          Self->ErrorMsg = "Root element namespace is not registered within this document.";
          return log.warning(ERR::InvalidData);
+      }
+   }
+
+   if (not root_has_namespace) {
+      std::string root_prefix;
+      if (!document_root->Attribs.empty()) {
+         std::string_view qualified_name(document_root->Attribs[0].Name);
+         auto colon = qualified_name.find(':');
+         if (colon != std::string::npos) {
+            root_prefix.assign(qualified_name.begin(), qualified_name.begin() + colon);
+         }
+      }
+
+      std::string prefix_attribute;
+      if (!root_prefix.empty()) {
+         prefix_attribute = "xmlns:";
+         prefix_attribute.append(root_prefix);
+      }
+
+      for (size_t index = 1u; index < document_root->Attribs.size(); ++index) {
+         const auto &attrib = document_root->Attribs[index];
+         if (pf::iequals(attrib.Name, "xmlns")) {
+            assign_root_namespace(attrib.Value);
+            if (root_has_namespace) break;
+         }
+         else if ((!prefix_attribute.empty()) and pf::iequals(attrib.Name, prefix_attribute)) {
+            assign_root_namespace(attrib.Value);
+            if (root_has_namespace) break;
+         }
       }
    }
 


### PR DESCRIPTION
## Summary
- update XML_ValidateDocument to capture the document root namespace when NamespaceID is unset
- reuse the detected namespace when comparing against the schema target namespace so validation works without namespace-aware parsing

## Testing
- build/agents/release/parasol --set-volume scripts=/workspace/parasol/scripts --log-warning /tmp/test.fluid
- build/agents/release/parasol --set-volume scripts=/workspace/parasol/scripts --log-warning /tmp/test_fail.fluid

------
https://chatgpt.com/codex/tasks/task_e_68dd11ac90ec832e98d26ff93fb6147f