### PR TITLE
Improve codex_setup.sh resilience when fetching artifacts

### DIFF
--- a/tools/codex_setup.sh
+++ b/tools/codex_setup.sh
@@ -12,6 +12,25 @@ ARTIFACT_NAME="${ARTIFACT_NAME:-parasol-install-ubuntu-latest-FastBuild}"
 DEST_DIR="${DEST_DIR:-install/agents}"
 GITHUB_HOST="${GITHUB_HOST:-github.com}"
 GH_TOKEN=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
+DEFAULT_REPOSITORY="${DEFAULT_REPOSITORY:-team-parasol/parasol}"
+RELEASE_REPOSITORY="${RELEASE_REPOSITORY:-parasol-framework/parasol}"
+
+# The GitHub CLI expects authentication tokens to be supplied via the
+# GITHUB_TOKEN environment variable.  Older versions of this script
+# populated GH_TOKEN instead, which meant the non-interactive login step
+# failed and the artefact download never happened.  Normalise the token so
+# that GITHUB_TOKEN is always set when either variable is provided.
+if [[ -z "${GITHUB_TOKEN:-}" && -n "${GH_TOKEN:-}" ]]; then
+   export GITHUB_TOKEN="${GH_TOKEN}"
+fi
+
+# Older versions of gh (including the one available in this environment)
+# do not support the --hostname flag.  Setting GH_HOST ensures the CLI
+# operates against the requested GitHub instance without requiring the
+# newer flag.
+export GH_HOST="${GITHUB_HOST}"
+
+gh_authenticated=false
 
 install_gh() {
    if command -v gh >/dev/null 2>&1; then
@@ -46,59 +65,187 @@ ensure_gh() {
 }
 
 ensure_auth() {
-   if gh auth status --hostname "${GITHUB_HOST}" >/dev/null 2>&1; then
+   if gh auth status >/dev/null 2>&1; then
+      gh_authenticated=true
       return
    fi
 
    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-      printf '%s\n' "${GITHUB_TOKEN}" \
-         | gh auth login --with-token --scopes "actions:read" --hostname "${GITHUB_HOST}" >/dev/null
-      if gh auth status --hostname "${GITHUB_HOST}" >/dev/null 2>&1; then
+      if printf '%s\n' "${GITHUB_TOKEN}" \
+         | gh auth login --with-token --scopes "actions:read" >/dev/null; then
+         if gh auth status >/dev/null 2>&1; then
+            gh_authenticated=true
+            return
+         fi
+      fi
+   fi
+
+   echo "warning: gh is not authenticated; continuing without CI artefact support." >&2
+   gh_authenticated=false
+}
+
+discover_repo() {
+   if [[ -n "${REPOSITORY:-}" ]]; then
+      printf '%s\n' "${REPOSITORY}"
+      return
+   fi
+
+   if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      local remote_url
+      if remote_url="$(git remote get-url origin 2>/dev/null)"; then
+         :
+      elif remote_url="$(git remote get-url upstream 2>/dev/null)"; then
+         :
+      else
+         remote_url=""
+      fi
+
+      if [[ -n "${remote_url}" ]]; then
+         remote_url="${remote_url%.git}"
+         remote_url="${remote_url%/}"
+         printf '%s\n' "${remote_url}" | sed -E 's#.*[:/]([^/:]+/[^/:]+)$#\1#'
          return
       fi
    fi
 
-   echo "error: gh is not authenticated. Provide GITHUB_TOKEN with actions:read scope or run 'gh auth login'." >&2
-   exit 1
+   printf '%s\n' "${DEFAULT_REPOSITORY}"
 }
 
 ensure_gh
 ensure_auth
 
-run_id="$(gh run list \
-   --workflow "${WORKFLOW_FILE}" \
-   --branch "${BRANCH_NAME}" \
-   --event push \
-   --status success \
-   --limit 1 \
-   --json databaseId \
-   --jq '.[0].databaseId' \
-   --hostname "${GITHUB_HOST}")"
-
-if [[ -z "${run_id}" ]]; then
-   echo "error: no successful runs found for ${WORKFLOW_FILE} on ${BRANCH_NAME}." >&2
-   exit 1
-fi
-
-echo "Using workflow run ${run_id}"
-
+repository="$(discover_repo)"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 
-# download extracts the artifact straight into tmp_dir/ARTIFACT_NAME
-gh run download "${run_id}" \
-   --name "${ARTIFACT_NAME}" \
-   --dir "${tmp_dir}"
+artifact_tarball=""
+download_source=""
+tar_strip=""
 
-tarball="$(find "${tmp_dir}" -type f -name '*.tar.gz' -print -quit)"
-if [[ -z "${tarball}" ]]; then
-   echo "error: no .tar.gz found in downloaded artifact; verify the CI packaging step." >&2
+download_ci_artifact() {
+   if [[ "${gh_authenticated}" != true ]]; then
+      return 1
+   fi
+
+   local run_id
+   if ! run_id="$(gh run list \
+      --workflow "${WORKFLOW_FILE}" \
+      --branch "${BRANCH_NAME}" \
+      --event push \
+      --status success \
+      --limit 1 \
+      --json databaseId \
+      --jq '.[0].databaseId' \
+      --repo "${repository}" 2>/dev/null)"; then
+      echo "warning: failed to query workflow runs via gh; falling back to release artefact." >&2
+      return 1
+   fi
+
+   if [[ -z "${run_id}" ]]; then
+      echo "warning: no successful runs found for ${WORKFLOW_FILE} on ${BRANCH_NAME}; falling back to release artefact." >&2
+      return 1
+   fi
+
+   echo "Using workflow run ${run_id}"
+
+   if ! gh run download "${run_id}" \
+      --name "${ARTIFACT_NAME}" \
+      --dir "${tmp_dir}" \
+      --repo "${repository}" >/dev/null 2>&1; then
+      echo "warning: failed to download CI artefact; falling back to release artefact." >&2
+      return 1
+   fi
+
+   local tarball
+   tarball="$(find "${tmp_dir}" -type f -name '*.tar.gz' -print -quit)"
+   if [[ -z "${tarball}" ]]; then
+      echo "warning: no .tar.gz found in downloaded CI artefact; falling back to release artefact." >&2
+      return 1
+   fi
+
+   artifact_tarball="${tarball}"
+   download_source="workflow ${run_id}"
+   tar_strip=""
+   return 0
+}
+
+download_release_artifact() {
+   local api_url="https://api.github.com/repos/${RELEASE_REPOSITORY}/releases/latest"
+   local dest="${tmp_dir}/${ARTIFACT_NAME}.tar.gz"
+   local asset_name=""
+   local asset_url=""
+
+   echo "Querying latest release from ${api_url}"
+   local json_file="${tmp_dir}/release.json"
+   if ! curl -fsSL "${api_url}" -o "${json_file}"; then
+      echo "error: failed to query ${api_url}." >&2
+      return 1
+   fi
+
+   if ! readarray -t asset_info < <(python3 - "${json_file}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as fh:
+   data = json.load(fh)
+selected = None
+for asset in data.get('assets', []):
+   name = asset.get('name') or ''
+   url = asset.get('browser_download_url')
+   if not url:
+      continue
+   if name.endswith('.tar.gz'):
+      selected = (name, url)
+      if 'linux' in name.lower():
+         break
+
+if not selected:
+   sys.exit(1)
+
+print(selected[0])
+print(selected[1])
+PY
+   ); then
+      echo "error: unable to identify a release artefact for ${RELEASE_REPOSITORY}." >&2
+      return 1
+   fi
+
+   asset_name="${asset_info[0]:-}"
+   asset_url="${asset_info[1]:-}"
+
+   if [[ -z "${asset_url}" ]]; then
+      echo "error: latest release for ${RELEASE_REPOSITORY} does not contain a downloadable tarball." >&2
+      return 1
+   fi
+
+   echo "Downloading release artefact ${asset_name}"
+   if curl -fsSL "${asset_url}" -o "${dest}"; then
+      artifact_tarball="${dest}"
+      download_source="release ${RELEASE_REPOSITORY}:${asset_name}"
+      tar_strip="--strip-components=1"
+      return 0
+   fi
+
+   echo "error: failed to download release artefact from ${asset_url}." >&2
+   return 1
+}
+
+if ! download_ci_artifact; then
+   download_release_artifact
+fi
+
+if [[ -z "${artifact_tarball}" ]]; then
+   echo "error: no artefact available; aborting." >&2
    exit 1
 fi
 
 mkdir -p "${DEST_DIR}"
 rm -rf "${DEST_DIR:?}/"*
 
-tar -xzf "${tarball}" -C "${DEST_DIR}"
+tar -xzf "${artifact_tarball}" -C "${DEST_DIR}" ${tar_strip}
 
-echo "Restored ${ARTIFACT_NAME} into ${DEST_DIR}"
+if [[ -n "${download_source}" ]]; then
+   echo "Restored ${ARTIFACT_NAME} into ${DEST_DIR} from ${download_source}"
+else
+   echo "Restored ${ARTIFACT_NAME} into ${DEST_DIR}"
+fi


### PR DESCRIPTION
## Summary
- normalise GitHub authentication for older gh versions and detect repository details when remotes are absent
- fall back to downloading the latest public release when CI artefact access fails and automatically strip the archive root
- add compatibility fixes for legacy gh CLI flags and improved messaging around authentication status

## Testing
- `bash tools/codex_setup.sh`
- `./install/agents/parasol --help`


------
https://chatgpt.com/codex/tasks/task_e_68dd638b7d94832e9571c3d6af83eca4