### PR TITLE
[Network] Added support for universally compatible sockets

### DIFF
--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -28,7 +28,7 @@ static void disconnect(extClientSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
-   log.branch("Disconnecting socket handle %d", Self->Handle);
+   log.branch("Disconnecting socket handle %d", Self->Handle.int_value());
 
    if (Self->Handle != NOHANDLE) {
 
@@ -109,7 +109,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
 
                   log.msg("SSL socket handshake requested by server.");
                   Self->HandshakeStatus = SHS::WRITE;
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_write<extClientSocket>), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, ssl_handshake_write<extClientSocket>, Self);
                   return ERR::Okay;
 
                case SSL_ERROR_SYSCALL:
@@ -136,7 +136,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
          // For this reason we set the RECALL flag so that we can be called again manually when we know that there is
          // data pending.
 
-         RegisterFD((HOSTHANDLE)Self->Handle, RFD::RECALL|RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&server_incoming_from_client), Self);
+         RegisterFD(Self->Handle.hosthandle(), RFD::RECALL|RFD::READ|RFD::SOCKET, &server_incoming_from_client, Self);
       }
 
       return ERR::Okay;
@@ -173,13 +173,13 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
 //********************************************************************************************************************
 // Data has arrived from a client's socket handle.
 
-static void server_incoming_from_client(HOSTHANDLE Handle, extClientSocket *client)
+static void server_incoming_from_client(SocketHandle Handle, extClientSocket *client)
 {
    pf::Log log(__FUNCTION__);
    if (!client->Client) return;
    auto Server = (extNetSocket *)(client->Client->Owner);
 
-   if (client->Handle IS NOHANDLE) {
+   if (client->Handle.is_invalid()) {
       log.warning(ERR::InvalidState); // Socket closed but receiving data.
       return;
    }
@@ -245,7 +245,7 @@ static void server_incoming_from_client(HOSTHANDLE Handle, extClientSocket *clie
    Server->InUse++;
    client->ReadCalled = false;
 
-   log.traceBranch("Handle: %" PRId64 ", Socket: %d, Client: %d", (int64_t)Handle, Server->UID, client->UID);
+   log.traceBranch("Handle: %d, Socket: %d, Client: %d", Handle.int_value(), Server->UID, client->UID);
 
    auto error = ERR::Okay;
    if (Server->Incoming.defined()) {
@@ -280,7 +280,7 @@ static void server_incoming_from_client(HOSTHANDLE Handle, extClientSocket *clie
 // no data is being written to the queue, the program will not be able to sleep until the client stops listening
 // to the write queue.
 
-static void clientsocket_outgoing(HOSTHANDLE Void, extClientSocket *ClientSocket)
+static void clientsocket_outgoing(SocketHandle Void, extClientSocket *ClientSocket)
 {
    pf::Log log(__FUNCTION__);
    auto Server = (extNetSocket *)(ClientSocket->Client->Owner);
@@ -361,9 +361,9 @@ static void clientsocket_outgoing(HOSTHANDLE Void, extClientSocket *ClientSocket
       // we don't tax system resources.
 
       if (ClientSocket->WriteQueue.Buffer.empty()) {
-         log.trace("[NetSocket:%d] Write-queue listening on FD %d will now stop.", Server->UID, ClientSocket->Handle);
+         log.trace("[NetSocket:%d] Write-queue listening on FD %d will now stop.", Server->UID, ClientSocket->Handle.int_value());
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)ClientSocket->Handle, RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
+            RegisterFD(ClientSocket->Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
          #elif _WIN32
             win_socketstate(ClientSocket->Handle, std::nullopt, false);
          #endif
@@ -467,7 +467,7 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
          Self->SSLHandle = ssl_create_context(false, true); // No verification, server mode
          if (Self->SSLHandle) {
             ssl_set_server_certificate(server->SSLHandle, Self->SSLHandle);
-            ssl_set_socket(Self->SSLHandle, (void*)(size_t)Self->Handle); // Set socket handle for server-side SSL
+            ssl_set_socket(Self->SSLHandle, (void*)(size_t)Self->Handle.socket()); // Set socket handle for server-side SSL
             Self->State = NTC::HANDSHAKING;
          }
          else Self->State = NTC::DISCONNECTED;
@@ -518,7 +518,7 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
 #endif
 
 #ifdef __linux__
-   RegisterFD(Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&server_incoming_from_client), Self);
+   RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_incoming_from_client, Self);
 #elif _WIN32
    win_socket_reference(Self->Handle, Self);
 #endif
@@ -555,7 +555,7 @@ static ERR CLIENTSOCKET_Read(extClientSocket *Self, struct acRead *Args)
 {
    pf::Log log;
    if ((!Args) or (!Args->Buffer)) return log.error(ERR::NullArgs);
-   if (Self->Handle IS NOHANDLE) {
+   if (Self->Handle.is_invalid()) {
       // Lack of a handle means that disconnection has already been processed, so the client code
       // shouldn't be calling us (client probably needs to be plugged into the feedback mechanisms)
       return log.warning(ERR::Disconnected);
@@ -597,7 +597,7 @@ static ERR CLIENTSOCKET_Write(extClientSocket *Self, struct acWrite *Args)
 
    auto server = (extNetSocket *)(Self->Client->Owner);
 
-   if ((Self->Handle IS NOHANDLE) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
+   if ((Self->Handle.is_invalid()) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
       log.trace("Saving %d bytes to queue.", Args->Length);
       Self->WriteQueue.write(Args->Buffer, std::min<size_t>(Args->Length, server->MsgLimit));
       return ERR::Okay;
@@ -620,7 +620,7 @@ static ERR CLIENTSOCKET_Write(extClientSocket *Self, struct acWrite *Args)
          log.trace("Error: '%s', queuing %d/%d bytes for transfer...", GetErrorMsg(error), Args->Length - len, Args->Length);
          Self->WriteQueue.write((int8_t *)Args->Buffer + len, std::min<size_t>(Args->Length - len, server->MsgLimit));
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&clientsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &clientsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif
@@ -691,7 +691,7 @@ static ERR CS_SET_State(extClientSocket *Self, NTC Value)
       if ((Self->State IS NTC::CONNECTED) and ((!Self->WriteQueue.Buffer.empty()))) {
          log.msg("Sending queued data to server on connection.");
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&clientsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &clientsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif

--- a/src/network/netsocket/netsocket.cpp
+++ b/src/network/netsocket/netsocket.cpp
@@ -90,16 +90,12 @@ static size_t glMaxWriteLen = 16 * 1024;
 //********************************************************************************************************************
 // Prototypes for internal methods
 
-#ifdef __linux__
-static void client_connect(HOSTHANDLE, APTR);
-#endif
-
-static void netsocket_incoming(SOCKET_HANDLE, extNetSocket *);
-static void netsocket_outgoing(SOCKET_HANDLE, extNetSocket *);
-static void server_incoming_from_client(HOSTHANDLE, extClientSocket *);
-static void clientsocket_outgoing(HOSTHANDLE, extClientSocket *);
+static void netsocket_incoming(SocketHandle, extNetSocket *);
+static void netsocket_outgoing(SocketHandle, extNetSocket *);
+static void server_incoming_from_client(SocketHandle, extClientSocket *);
+static void clientsocket_outgoing(SocketHandle, extClientSocket *);
 static void free_client(extNetSocket *, objNetClient *);
-static void server_accept_client(SOCKET_HANDLE, extNetSocket *);
+static void server_accept_client(SocketHandle, extNetSocket *);
 static void free_socket(extNetSocket *);
 static CSTRING netsocket_state(NTC Value);
 
@@ -235,7 +231,7 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
       return;
    }
 
-   log.msg("Received callback on DNS resolution.  Handle: %d", Socket->Handle);
+   log.msg("Received callback on DNS resolution.  Handle: %d", Socket->Handle.int_value());
 
    // Start connect()
 
@@ -322,13 +318,13 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
             }
 
             Socket->setState(NTC::CONNECTING);
-            RegisterFD((HOSTHANDLE)Socket->Handle, RFD::READ|RFD::SOCKET, (void (*)(HOSTHANDLE, APTR))&netsocket_incoming, Socket);
-            RegisterFD((HOSTHANDLE)Socket->Handle, RFD::WRITE|RFD::SOCKET, &client_connect, Socket);
+            RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
+            RegisterFD(Socket->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &client_connect, Socket);
          }
          else {
             log.trace("IPv6 connect() successful.");
             Socket->setState(NTC::CONNECTED);
-            RegisterFD((HOSTHANDLE)Socket->Handle, RFD::READ|RFD::SOCKET, (void (*)(HOSTHANDLE, APTR))&netsocket_incoming, Socket);
+            RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
          }
       #endif
       return;
@@ -365,13 +361,13 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
             }
 
             Socket->setState(NTC::CONNECTING);
-            RegisterFD((HOSTHANDLE)Socket->Handle, RFD::READ|RFD::SOCKET, (void (*)(HOSTHANDLE, APTR))&netsocket_incoming, Socket);
-            RegisterFD((HOSTHANDLE)Socket->Handle, RFD::WRITE|RFD::SOCKET, &client_connect, Socket);
+            RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
+            RegisterFD(Socket->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &client_connect, Socket);
          }
          else {
             log.trace("IPv4-mapped IPv6 connect() successful.");
             Socket->setState(NTC::CONNECTED);
-            RegisterFD((HOSTHANDLE)Socket->Handle, RFD::READ|RFD::SOCKET, (void (*)(HOSTHANDLE, APTR))&netsocket_incoming, Socket);
+            RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
          }
          return;
       #elif _WIN32
@@ -423,17 +419,17 @@ static void connect_name_resolved(extNetSocket *Socket, ERR Error, const std::st
       }
 
       Socket->setState(NTC::CONNECTING);
-      RegisterFD((HOSTHANDLE)Socket->Handle, RFD::READ|RFD::SOCKET, (void (*)(HOSTHANDLE, APTR))&netsocket_incoming, Socket);
+      RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
 
       // The write queue will be signalled once the connection process is completed.
 
-      RegisterFD((HOSTHANDLE)Socket->Handle, RFD::WRITE|RFD::SOCKET, &client_connect, Socket);
+      RegisterFD(Socket->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &client_connect, Socket);
    }
    else {
       log.trace("connect() successful.");
 
       Socket->setState(NTC::CONNECTED);
-      RegisterFD((HOSTHANDLE)Socket->Handle, RFD::READ|RFD::SOCKET, (void (*)(HOSTHANDLE, APTR))&netsocket_incoming, Socket);
+      RegisterFD(Socket->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Socket);
    }
 
 #elif _WIN32
@@ -464,7 +460,7 @@ static ERR connect_timeout_handler(OBJECTPTR Subscriber, int64_t TimeElapsed, in
       return ERR::Terminate;
    }
 
-   if (socket->Handle != NOHANDLE) free_socket(socket);
+   if (socket->Handle.is_valid()) free_socket(socket);
 
    // Cancel DNS resolution if in progress
    if (socket->NetLookup) { FreeResource(socket->NetLookup); socket->NetLookup = nullptr; }
@@ -745,7 +741,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    pf::Log log;
    ERR error;
 
-   if (Self->Handle != NOHANDLE) return ERR::Okay; // The socket has been pre-configured by the developer
+   if (Self->Handle.is_valid()) return ERR::Okay; // The socket has been pre-configured by the developer
 
    if ((Self->Flags & NSF::UDP) != NSF::NIL) { // Set UDP-specific defaults
       if (!Self->MaxPacketSize) Self->MaxPacketSize = 65507; // Standard UDP max packet size
@@ -766,7 +762,8 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    int socket_type = ((Self->Flags & NSF::UDP) != NSF::NIL) ? SOCK_DGRAM : SOCK_STREAM;
    int protocol = ((Self->Flags & NSF::UDP) != NSF::NIL) ? IPPROTO_UDP : IPPROTO_TCP;
 
-   if ((Self->Handle = socket(PF_INET6, socket_type, protocol)) != NOHANDLE) {
+   if (auto sock = socket(PF_INET6, socket_type, protocol); sock != -1) {
+      Self->Handle = SocketHandle(sock);
       Self->IPV6 = true;
 
       // Enable dual-stack mode (accept both IPv4 and IPv6)
@@ -780,7 +777,8 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
          setsockopt(Self->Handle, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
       }
    }
-   else if ((Self->Handle = socket(PF_INET, socket_type, protocol)) != NOHANDLE) {
+   else if (auto sock = socket(PF_INET, socket_type, protocol); sock != -1) {
+      Self->Handle = SocketHandle(sock);
       Self->IPV6 = false;
 
       if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP-specific options
@@ -809,7 +807,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    bool is_ipv6;
    bool is_udp = ((Self->Flags & NSF::UDP) != NSF::NIL);
    Self->Handle = win_socket_ipv6(Self, true, false, is_ipv6, is_udp);
-   if (Self->Handle IS NOHANDLE) return ERR::SystemCall;
+   if (Self->Handle.is_invalid()) return ERR::SystemCall;
    Self->IPV6 = is_ipv6;
 
 #endif
@@ -881,10 +879,10 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             if ((result = bind(Self->Handle, (struct sockaddr *)&addr, sizeof(addr))) != -1) {
                if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP server - needs listen()
                   listen(Self->Handle, Self->Backlog);
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&server_accept_client), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_accept_client, Self);
                }
                else { // UDP server - just register for data reception
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
                }
                return ERR::Okay;
             }
@@ -956,10 +954,10 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
             if ((result = bind(Self->Handle, (struct sockaddr *)&addr, sizeof(addr))) != -1) {
                if ((Self->Flags & NSF::UDP) IS NSF::NIL) { // TCP server - needs listen()
                   listen(Self->Handle, Self->Backlog);
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&server_accept_client), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_accept_client, Self);
                }
                else { // UDP server - just register for data reception
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
                }
                return ERR::Okay;
             }
@@ -999,7 +997,7 @@ static ERR NETSOCKET_Init(extNetSocket *Self)
    else if ((Self->Flags & NSF::UDP) != NSF::NIL) {
       // UDP client sockets need to be registered for incoming data on Linux
       #ifdef __linux__
-      RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+      RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
       #endif
       return ERR::Okay;
    }
@@ -1195,7 +1193,7 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
       return ERR::NoSupport;
    }
 
-   if (Self->Handle IS NOHANDLE) return log.warning(ERR::Disconnected);
+   if (Self->Handle.is_invalid()) return log.warning(ERR::Disconnected);
 
    Self->ReadCalled = true;
    Args->Result = 0;
@@ -1249,7 +1247,7 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
 
                       log.msg("SSL socket handshake requested by server.");
                       Self->HandshakeStatus = SHS::WRITE;
-                      RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_write<extNetSocket>), Self);
+                      RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, ssl_handshake_write<extNetSocket>, Self);
                       return ERR::Okay;
 
                    case SSL_ERROR_SYSCALL:
@@ -1276,7 +1274,7 @@ static ERR NETSOCKET_Read(extNetSocket *Self, struct acRead *Args)
             // For this reason we set the RECALL flag so that we can be called again manually when we know that there is
             // data pending.
 
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::RECALL|RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::RECALL|RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
          }
 
          return ERR::Okay;
@@ -1339,7 +1337,7 @@ static ERR NETSOCKET_Write(extNetSocket *Self, struct acWrite *Args)
       return ERR::NoSupport;
    }
 
-   if ((Self->Handle IS NOHANDLE) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
+   if ((Self->Handle.is_invalid()) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
       log.trace("Saving %d bytes to queue.", Args->Length);
       Self->WriteQueue.write(Args->Buffer, std::min<size_t>(Args->Length, Self->MsgLimit));
       return ERR::Okay;
@@ -1366,7 +1364,7 @@ static ERR NETSOCKET_Write(extNetSocket *Self, struct acWrite *Args)
          log.trace("Error: '%s', queuing %d/%d bytes for transfer...", GetErrorMsg(error), Args->Length - len, Args->Length);
          Self->WriteQueue.write((int8_t *)Args->Buffer + len, std::min<size_t>(Args->Length - len, Self->MsgLimit));
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -5,16 +5,14 @@ static void free_socket(extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
-   log.branch("Handle: %d", Self->Handle);
+   log.branch("Handle: %d", Self->Handle.int_value());
 
-   if (Self->Handle != NOHANDLE) {
+   if (Self->Handle.is_valid()) {
       log.trace("Deregistering socket.");
-#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
-      DeregisterFD((HOSTHANDLE)Self->Handle);
-#pragma GCC diagnostic warning "-Wint-to-pointer-cast"
+      DeregisterFD(Self->Handle.hosthandle());
 
       if (!Self->ExternalSocket) CLOSESOCKET_THREADED(Self->Handle);
-      Self->Handle = NOHANDLE;
+      Self->Handle = SocketHandle();
    }
 
    Self->WriteQueue.Buffer.clear();
@@ -212,13 +210,13 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
 // Called when a server socket handle detects a new client wanting to connect to it.
 // Used by Win32 (Windows message loop) & Linux (FD hook)
 
-static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
+static void server_accept_client(SocketHandle FD, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
    uint8_t ip[8];
-   SOCKET_HANDLE clientfd;
+   SocketHandle clientfd;
 
-   log.traceBranch("FD: %d", FD);
+   log.traceBranch("FD: %d", FD.int_value());
 
    pf::SwitchContext context(Self);
 
@@ -252,7 +250,7 @@ static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
          struct sockaddr_storage addr_storage;
          socklen_t len = sizeof(addr_storage);
          clientfd = accept(FD, (struct sockaddr *)&addr_storage, &len);
-         if (clientfd IS NOHANDLE) return;
+         if (clientfd.is_invalid()) return;
 
          int nodelay = 1;
          setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
@@ -331,7 +329,7 @@ static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
          socklen_t len = sizeof(addr);
          clientfd = accept(FD, (struct sockaddr *)&addr, &len);
 
-         if (clientfd != NOHANDLE) {
+         if (clientfd.is_valid()) {
             int nodelay = 1;
             setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
          }
@@ -340,7 +338,7 @@ static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
          clientfd = win_accept(Self, FD, (struct sockaddr *)&addr, &len);
       #endif
 
-      if (clientfd IS NOHANDLE) {
+      if (clientfd.is_invalid()) {
          log.warning("accept() failed to return an FD.");
          return;
       }
@@ -484,10 +482,9 @@ static void free_client(extNetSocket *Socket, objNetClient *Client)
 // See win32_netresponse() for the Windows version.
 
 #ifdef __linux__
-static void client_connect(SOCKET_HANDLE Void, APTR Data)
+static void netsocket_connect(SocketHandle Void, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
-   auto Self = (extNetSocket *)Data;
 
    pf::SwitchContext context(Self);
 
@@ -499,7 +496,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
 
    // Remove the write callback
 
-   RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::REMOVE, &client_connect, nullptr);
+   RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::REMOVE, &netsocket_connect, nullptr);
 
    #ifndef DISABLE_SSL
    if ((Self->SSLHandle) and (!result)) {
@@ -511,7 +508,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
       if (Self->Error != ERR::Okay) return;
 
       if (Self->State IS NTC::HANDSHAKING) {
-         RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+         RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
       }
       return;
    }
@@ -523,7 +520,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
       if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
 
       Self->setState(NTC::CONNECTED);
-      RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+      RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
       return;
    }
    else {
@@ -552,7 +549,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
 //
 // This function is called from win32_netresponse() and is managed outside of the normal message queue.
 
-static void netsocket_incoming(SOCKET_HANDLE FD, extNetSocket *Self)
+static void netsocket_incoming(SocketHandle FD, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
@@ -567,7 +564,7 @@ static void netsocket_incoming(SOCKET_HANDLE FD, extNetSocket *Self)
 
    if (Self->Terminating) { // Set by FreeWarning()
       log.trace("Socket terminating...", Self->UID);
-      if (Self->Handle != NOHANDLE) free_socket(Self);
+      if (Self->Handle.is_valid()) free_socket(Self);
       return;
    }
 
@@ -608,12 +605,12 @@ static void netsocket_incoming(SOCKET_HANDLE FD, extNetSocket *Self)
 #endif
 
    if (Self->IncomingRecursion) {
-      log.trace("[NetSocket:%d] Recursion detected on handle %" PRId64, Self->UID, (int64_t)FD);
+      log.trace("[NetSocket:%d] Recursion detected on handle %d", Self->UID, FD.int_value());
       if (Self->IncomingRecursion < 2) Self->IncomingRecursion++; // Indicate that there is more data to be received
       return;
    }
 
-   log.traceBranch("[NetSocket:%d] Socket: %" PRId64, Self->UID, (int64_t)FD);
+   log.traceBranch("[NetSocket:%d] Socket: %d", Self->UID, FD.int_value());
 
    Self->InUse++;
    Self->IncomingRecursion++;
@@ -654,8 +651,8 @@ restart:
    }
 
    if (error IS ERR::Terminate) {
-      log.traceBranch("Socket %d will be terminated.", FD);
-      if (Self->Handle != NOHANDLE) free_socket(Self);
+      log.traceBranch("Socket %d will be terminated.", FD.int_value());
+      if (Self->Handle.is_valid()) free_socket(Self);
    }
    else if (Self->IncomingRecursion > 1) {
       // If netsocket_incoming() was called again during the callback, there is more
@@ -689,7 +686,7 @@ restart:
 //
 // Called from either the Windows messaging logic or a Linux FD subscription.
 
-static void netsocket_outgoing(SOCKET_HANDLE Void, extNetSocket *Self)
+static void netsocket_outgoing(SocketHandle Void, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
@@ -760,9 +757,9 @@ static void netsocket_outgoing(SOCKET_HANDLE Void, extNetSocket *Self)
       // be assigned temporarily.
 
       if ((!Self->Outgoing.defined()) and (Self->WriteQueue.Buffer.empty())) {
-         log.trace("Write-queue listening on socket %d will now stop.", Self->UID, Self->Handle);
+         log.trace("Write-queue listening on socket %d will now stop.", Self->UID, Self->Handle.int_value());
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
+            RegisterFD(Self->Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
          #elif _WIN32
             if (auto error = win_socketstate(Self->Handle, std::nullopt, false); error != ERR::Okay) log.warning(error);
          #endif

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -31,6 +31,8 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
  #include <sys/resource.h>
 #endif
 
+#include <string.h>
+
 #include <parasol/main.h>
 #include <parasol/modules/network.h>
 #include <parasol/strings.hpp>
@@ -58,6 +60,8 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <cstring>
 #include <thread>
 #include <optional>
+
+//********************************************************************************************************************
 
 std::mutex glmThreads;
 std::unordered_set<std::shared_ptr<std::jthread>> glThreads;
@@ -89,13 +93,7 @@ enum class SHS : uint8_t {
 
 DEFINE_ENUM_FLAG_OPERATORS(SHS)
 
-#ifdef __linux__
-typedef int SOCKET_HANDLE;
-#elif _WIN32
-typedef uint32_t SOCKET_HANDLE; // NOTE: declared as uint32_t instead of SOCKET for now to avoid including winsock.h
-#else
-#error "No support for this platform"
-#endif
+//********************************************************************************************************************
 
 #ifdef _WIN32
    #define INADDR_NONE 0xffffffff
@@ -227,6 +225,7 @@ typedef uint32_t SOCKET_HANDLE; // NOTE: declared as uint32_t instead of SOCKET 
    }
 
 #elif _WIN32
+   #include "win32/winsockwrappers.h"
 
    #include <string.h>
 
@@ -243,11 +242,36 @@ typedef uint32_t SOCKET_HANDLE; // NOTE: declared as uint32_t instead of SOCKET 
 
 #else
    #error "No support for this platform"
+// For Linux, create a simple wrapper that behaves like an int but with methods
+class SocketHandle {
+private:
+   int socket_val;
+public:
+   SocketHandle() : socket_val(-1) {}
+   SocketHandle(int sock) : socket_val(sock) {}
+
+   operator int() const { return socket_val; }
+   operator bool() const { return socket_val != -1; }
+
+   int int_value() const { return socket_val; }
+   int hosthandle() const { return socket_val; }
+   int socket() const { return socket_val; }
+
+   bool is_valid() const { return socket_val != -1; }
+   bool is_invalid() const { return socket_val == -1; }
+
+   bool operator==(const SocketHandle& other) const { return socket_val == other.socket_val; }
+   bool operator!=(const SocketHandle& other) const { return socket_val != other.socket_val; }
+   bool operator==(int sock) const { return socket_val == sock; }
+   bool operator!=(int sock) const { return socket_val != sock; }
+
+   SocketHandle& operator=(int sock) { socket_val = sock; return *this; }
+};
 #endif
 
 class extClientSocket : public objClientSocket {
    public:
-   SOCKET_HANDLE Handle = NOHANDLE;
+   SocketHandle Handle;
    struct NetQueue WriteQueue; // Writes to the network socket are queued here in a buffer
    uint8_t OutgoingRecursion;  // Recursion manager
    uint8_t InUse;       // Recursion manager
@@ -265,9 +289,11 @@ class extClientSocket : public objClientSocket {
    #endif
 };
 
+//********************************************************************************************************************
+
 class extNetSocket : public objNetSocket {
    public:
-   SOCKET_HANDLE Handle = NOHANDLE;   // Handle of the socket
+   SocketHandle Handle;   // Handle of the socket
    FUNCTION Outgoing;
    FUNCTION Incoming;
    FUNCTION Feedback;
@@ -366,7 +392,7 @@ typedef ankerl::unordered_dense::map<std::string, DNSEntry, CaseInsensitiveHash,
 
 //********************************************************************************************************************
 
-static void CLOSESOCKET_THREADED(SOCKET_HANDLE Handle)
+static void CLOSESOCKET_THREADED(SocketHandle Handle)
 {
 #ifdef _WIN32
    win_deregister_socket(Handle);
@@ -390,7 +416,7 @@ static void CLOSESOCKET_THREADED(SOCKET_HANDLE Handle)
 
    std::lock_guard<std::mutex> lock(glmThreads);
    auto thread_ptr = std::make_shared<std::jthread>();
-   *thread_ptr = std::jthread([] (int Handle) { CLOSESOCKET(Handle); }, Handle);
+   *thread_ptr = std::jthread([] (SocketHandle Handle) { CLOSESOCKET(Handle); }, Handle);
    glThreads.insert(thread_ptr);
    // Don't detach, threads need to be joinable for proper cleanup
 }
@@ -464,7 +490,7 @@ static std::string glCertPath;
 
 //********************************************************************************************************************
 
-static void netsocket_incoming(SOCKET_HANDLE, extNetSocket *);
+static void netsocket_incoming(SocketHandle, extNetSocket *);
 static ERR resolve_name_receiver(APTR Custom, MSGID MsgID, int MsgType, APTR Message, int MsgSize);
 static ERR resolve_addr_receiver(APTR Custom, MSGID MsgID, int MsgType, APTR Message, int MsgSize);
 
@@ -946,7 +972,7 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
                case SSL_ERROR_WANT_READ:
                   log.trace("Handshake requested by server.");
                   Self->HandshakeStatus = SHS::READ;
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_read<extNetSocket>), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, ssl_handshake_read<extNetSocket>, Self);
                   return ERR::Okay;
 
                case SSL_ERROR_SYSCALL:

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -142,7 +142,7 @@ template <class T> ERR sslConnect(T *Self)
    if (!Self->SSLHandle) return ERR::FieldNotSet;
 
    std::string hostname = Self->Address ? Self->Address : "";
-   auto result = ssl_connect(Self->SSLHandle, (void *)(size_t)Self->Handle, hostname);
+   auto result = ssl_connect(Self->SSLHandle, (void *)(size_t)Self->Handle.socket(), hostname);
 
    switch (result) {
       case SSL_OK:


### PR DESCRIPTION
This pull request refactors the socket handling logic in both `clientsocket.cpp` and `netsocket.cpp` to use the new `SocketHandle` abstraction instead of raw integer handles. It updates function signatures, condition checks, and all usages of socket handles to leverage type-safe methods (`int_value()`, `hosthandle()`, `is_valid()`, `is_invalid()`, etc.), resulting in improved code safety and clarity. Additionally, it removes unnecessary casts and simplifies function pointer usage with `RegisterFD`.
