### PR TITLE
Fix XPath document retrieval and text functions

### DIFF
--- a/src/xml/xpath/functions/func_documents.cpp
+++ b/src/xml/xpath/functions/func_documents.cpp
@@ -539,7 +539,6 @@ XPathValue XPathFunctionLibrary::function_unparsed_text_lines(const std::vector<
    std::shared_ptr<std::string> text;
    if (!read_text_resource(Context.document, resolved, encoding, text)) return XPathValue(std::vector<XMLTag *>());
 
-   std::vector<XMLTag *> nodes;
    std::vector<std::string> lines;
 
    size_t start = 0;
@@ -555,6 +554,7 @@ XPathValue XPathFunctionLibrary::function_unparsed_text_lines(const std::vector<
       if (start > text->length()) lines.emplace_back(std::string());
    }
 
+   std::vector<XMLTag *> nodes(lines.size(), nullptr);
    return XPathValue(nodes, std::nullopt, lines);
 }
 

--- a/src/xml/xpath/xpath_axis.h
+++ b/src/xml/xpath/xpath_axis.h
@@ -103,7 +103,8 @@ class AxisEvaluator {
 
    // Helper methods for tag lookup
    void build_id_cache();
-   XMLTag * find_tag_by_id(int ID);
+   extXML * find_document_for_node(XMLTag *Node);
+   XMLTag * find_tag_by_id(XMLTag *ReferenceNode, int ID);
 
    public:
    explicit AxisEvaluator(extXML *XML, XPathArena &Arena) : xml(XML), arena(Arena) {}

--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -39,6 +39,8 @@ class XPathEvaluator {
    std::vector<XPathContext> context_stack;
    
    std::vector<AxisMatch> dispatch_axis(AxisType Axis, XMLTag *ContextNode, const XMLAttrib *ContextAttribute = nullptr);
+   extXML * resolve_document_for_node(XMLTag *Node) const;
+   bool is_foreign_document_node(XMLTag *Node) const;
    std::vector<XMLTag *> collect_step_results(const std::vector<AxisMatch> &,
       const std::vector<const XPathNode *> &, size_t, uint32_t, bool &);
    XPathValue evaluate_path_expression_value(const XPathNode *PathNode, uint32_t CurrentPrefix);


### PR DESCRIPTION
## Summary
- ensure axis evaluation resolves node ownership across documents and treats imported document roots as selectable results
- add XPath evaluator helpers to fall back to foreign document roots when child steps have no matches
- return placeholder node entries from `unparsed-text-lines()` so sequence indexing succeeds

## Testing
- ctest --build-config Release --test-dir build/agents -R xml_xpath_documents --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68dfd59621c0832ea1e7ab9db181640b