### PR TITLE
Add planning documents for XPath 2.0 feature work

### DIFF
--- a/docs/plans/xpath_flwor_clauses_plan.md
+++ b/docs/plans/xpath_flwor_clauses_plan.md
@@ -1,0 +1,63 @@
+# Plan: Implement Missing XPath 2.0 FLWOR Clauses
+
+## Objective
+Extend the XPath parser and evaluator to support `where`, `order by`, `group by`, and `count` clauses in FLWOR expressions while maintaining compatibility with existing behaviour.
+
+## Assumptions & Constraints
+- New clauses must integrate with any future general sequence representation.
+- Respect repository coding standards and avoid introducing performance regressions.
+- Grouping and ordering must handle collation settings consistent with existing XPath infrastructure.
+
+## Test Strategy (Defined Up-Front)
+1. **New Fluid Tests**
+   - Create dedicated tests under `src/xml/tests/` for each clause:
+     - `where`: filtering with boolean predicates including atomic comparisons.
+     - `order by`: ordering strings, numbers, and nodes with ascending/descending options.
+     - `group by`: grouping values and verifying representative outputs.
+     - `count`: verifying positional counting outputs and interactions with other clauses.
+   - Add negative tests covering invalid clause orderings and incompatible expressions.
+2. **Regression**
+   - Run existing XPath FLWOR tests to confirm no regressions in baseline behaviour.
+
+## Work Breakdown Structure
+### 1. Research & Design
+- Review XPath 2.0 FLWOR grammar and semantics to clarify clause ordering and evaluation rules.
+- Inspect existing `XPathParser` FLWOR handling to determine extension points for new clauses.
+- Outline evaluator data flow to accommodate filtering, ordering, grouping, and counting.
+
+### 2. AST Extensions
+- Update `src/xml/xpath/xpath_ast.h/.cpp` to define nodes/structures representing optional FLWOR clauses.
+- Ensure AST serialisation/debug helpers reflect new structures.
+
+### 3. Parser Enhancements
+- Modify `parse_flwor_expr` in `src/xml/xpath/xpath_parser.cpp` to parse optional clauses in canonical order.
+- Enforce syntax rules (e.g., `group by` must precede `order by`).
+- Add descriptive error messages for malformed clause sequences.
+
+### 4. Evaluator Implementation
+- Extend `XPathEvaluator` in `src/xml/xpath/xpath_evaluator.cpp` to:
+  - Apply `where` predicates to intermediate bindings.
+  - Perform stable sorting for `order by` with support for ascending/descending and collation resolution.
+  - Implement `group by` result bucketing, ensuring grouped variable visibility and aggregated sequence construction.
+  - Track positional counters for `count` clause outputs.
+- Integrate with sequence support for handling atomic values.
+
+### 5. Auxiliary Utilities
+- Add helper routines for grouping keys, collation lookup, and stable sort operations if not already present.
+- Ensure memory management uses existing arenas or reference-counting mechanisms.
+
+### 6. Testing & Verification
+- Implement the planned Fluid tests first to lock expected behaviours before modifying parser/evaluator code.
+- Rebuild XML module: `cmake --build build/agents --config Release --target xml --parallel`.
+- Run targeted tests (new and existing) with `ctest --build-config Release --test-dir build/agents -L xml`.
+- Investigate and fix any failures, ensuring deterministic ordering for tests.
+
+### 7. Documentation & Cleanup
+- Update inline comments and developer docs to describe new clause support.
+- Remove temporary instrumentation and verify compliance with coding standards.
+- Prepare release notes or changelog entries if required.
+
+## Risk Mitigation
+- Implement clauses incrementally (e.g., `where` first) with dedicated tests per step.
+- Use feature flags or capability checks to avoid breaking existing consumers during development.
+- Carefully handle sorting/grouping edge cases such as NaN, collation mismatches, or empty groups.

--- a/docs/plans/xpath_sequence_items_plan.md
+++ b/docs/plans/xpath_sequence_items_plan.md
@@ -1,0 +1,56 @@
+# Plan: Implement Full XPath 2.0 Sequence Item Support
+
+## Objective
+Expand the XPath engine so it can represent, parse, and evaluate general item sequences (nodes and arbitrary atomic values) instead of limiting results to node sets.
+
+## Assumptions & Constraints
+- Maintain existing public APIs where possible; internal data structures may change.
+- Follow repository coding standards (three-space indent, `IS` macro, `and`/`or`, etc.).
+- Preserve backward compatibility with existing XPath 1.0 behaviours.
+
+## Test Strategy (Defined Up-Front)
+1. **Unit/Regression Tests**
+   - Add new Fluid tests under `src/xml/tests/` to validate handling of mixed sequences (nodes + atomic values) and sequence operators/functions.
+   - Cover edge cases such as empty sequences, singleton atomic sequences, and nested FLWOR results producing atomic sequences.
+2. **Existing Test Suite**
+   - Re-run existing XML/XPath tests to ensure no regressions.
+
+## Work Breakdown Structure
+### 1. Analysis & Design
+- Review current `XPathValueType`/`XPathValue` implementations to identify node-set assumptions.
+- Design a new representation for general sequences (e.g., tagged union of node pointers and atomic values within a sequence container).
+- Determine any required adjustments to reference counting or arena allocation.
+
+### 2. Update Core Data Structures
+- Modify `src/xml/xpath/xpath_functions.h/.cpp` to introduce the new sequence container types and helper utilities.
+- Ensure helper APIs expose iteration over mixed node/atomic items while remaining efficient.
+
+### 3. Parser Enhancements
+- Update `XPathParser::parse_expr` in `src/xml/xpath/xpath_parser.cpp` to implement the `exprSingle (',' exprSingle)*` grammar.
+- Introduce AST node(s) representing explicit sequence construction.
+- Validate compatibility with existing AST visitors/evaluators.
+
+### 4. Evaluator Changes
+- Adjust `XPathEvaluator` (`src/xml/xpath/xpath_evaluator.cpp`) to iterate over general sequences.
+- Update FLWOR, quantified expressions, and other evaluators to accept/produce sequences containing atomic values.
+- Ensure implicit conversions (boolean/numeric) respect XPath 2.0 sequence rules.
+
+### 5. Built-in Function Adjustments
+- Modify sequence-related built-ins in `src/xml/xpath/functions/func_sequences.cpp` and any others affected by the new representation.
+- Confirm functions such as `distinct-values`, `index-of`, `subsequence` operate correctly with mixed sequences.
+
+### 6. Testing & Verification
+- Implement the planned Fluid tests first, using the new expected behaviour as assertions.
+- Build the XML module: `cmake --build build/agents --config Release --target xml --parallel`.
+- Run XML module tests via `ctest --build-config Release --test-dir build/agents -L xml` (or equivalent label) after installation if required.
+- Investigate and resolve any failing tests.
+
+### 7. Documentation & Cleanup
+- Update inline comments or developer documentation if APIs change.
+- Ensure compliance with coding guidelines (spacing, naming, macros).
+- Remove temporary debugging output prior to commit.
+
+## Risk Mitigation
+- Maintain incremental commits (data structure, parser, evaluator, tests) to simplify debugging.
+- Use existing sequence utility patterns elsewhere in the codebase as references to avoid reinventing memory management strategies.
+- Validate performance impact with targeted benchmarks if sequence handling becomes heavier.

--- a/docs/plans/xpath_type_range_expressions_plan.md
+++ b/docs/plans/xpath_type_range_expressions_plan.md
@@ -1,0 +1,59 @@
+# Plan: Support XPath 2.0 Type and Range Expressions
+
+## Objective
+Add parsing and evaluation support for XPath 2.0 type-related expressions (`cast`, `castable`, `treat as`, `instance of`, `typeswitch`) and the `to` range operator.
+
+## Assumptions & Constraints
+- Leverage existing schema/type infrastructure under `src/xml/schema/`.
+- Ensure error reporting aligns with XPath 2.0 specification.
+- Maintain compliance with repository coding standards (macros, indentation, naming).
+
+## Test Strategy (Defined Up-Front)
+1. **New Fluid Tests**
+   - Add tests to `src/xml/tests/` covering:
+     - Successful and failing `cast`/`castable` operations for primitive types (string, decimal, date, etc.).
+     - `treat as` with both satisfied and violated type assertions.
+     - `instance of` across various schema types, including unions and lists.
+     - `typeswitch` evaluating multiple branches and default clauses.
+     - The `to` range operator for numeric sequences, including boundary conditions.
+   - Include negative tests for invalid syntax and type errors.
+2. **Regression**
+   - Re-run existing XPath tests to verify no regressions in previous functionality.
+
+## Work Breakdown Structure
+### 1. Grammar & Token Updates
+- Extend `XPathTokenizer` in `src/xml/xpath/xpath_parser.cpp` to recognise new keywords and the `to` operator.
+- Update `XPathTokenType` enums and related mappings.
+- Add any required AST node definitions in `src/xml/xpath/xpath_ast.h`.
+
+### 2. Parser Implementation
+- Implement parsing routines in `parse_expr` and helper functions for each new expression form.
+- Enforce correct precedence and associativity, especially for the `to` range operator.
+- Provide informative syntax errors when encountering unsupported forms.
+
+### 3. Evaluator Enhancements
+- Update `XPathEvaluator` (`src/xml/xpath/xpath_evaluator.cpp`) to evaluate the new expressions:
+  - Integrate with schema helpers for type checking and casting.
+  - Implement `typeswitch` control flow and variable scoping rules.
+  - Generate sequences for `to` ranges respecting numeric type promotion rules.
+- Ensure evaluation gracefully handles dynamic type errors per specification.
+
+### 4. Support Utilities
+- Add or refine helper functions within schema/type modules if additional conversions are required.
+- Ensure collation or timezone considerations are accounted for where applicable (e.g., date/time casts).
+
+### 5. Testing & Verification
+- Implement the planned Fluid tests before modifying the core evaluator to lock expected behaviours.
+- Build XML module: `cmake --build build/agents --config Release --target xml --parallel`.
+- Execute targeted tests via `ctest --build-config Release --test-dir build/agents -L xml`.
+- Address any failing cases, confirming detailed error messages where expected.
+
+### 6. Documentation & Cleanup
+- Update comments or developer documentation highlighting support for new expression types.
+- Double-check coding standards (indentation, macros, British English spelling).
+- Remove temporary logging or debug helpers prior to final commit.
+
+## Risk Mitigation
+- Develop and test each expression type incrementally to localise issues.
+- Consult XPath 2.0 specification for edge-case behaviour (e.g., numeric ranges with NaN or INF values).
+- Add asserts or validation helpers to prevent incorrect schema interactions.


### PR DESCRIPTION
## Summary
- add a detailed plan for implementing full XPath 2.0 sequence item support
- document the work plan to deliver missing XPath 2.0 FLWOR clauses
- outline the approach for adding XPath 2.0 type and range expressions

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e034613ab8832eaf32eff3d138d518