### PR TITLE
Refactored socket types

### DIFF
--- a/src/network/clientsocket/clientsocket.cpp
+++ b/src/network/clientsocket/clientsocket.cpp
@@ -28,9 +28,9 @@ static void disconnect(extClientSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
-   log.branch("Disconnecting socket handle %d", Self->Handle);
+   log.branch("Disconnecting socket handle %d", Self->Handle.int_value());
 
-   if (Self->Handle != NOHANDLE) {
+   if (Self->Handle.is_valid()) {
 
 #ifdef __linux__
       DeregisterFD(Self->Handle);
@@ -109,7 +109,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
 
                   log.msg("SSL socket handshake requested by server.");
                   Self->HandshakeStatus = SHS::WRITE;
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_write<extClientSocket>), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, ssl_handshake_write_clientsocket, Self);
                   return ERR::Okay;
 
                case SSL_ERROR_SYSCALL:
@@ -136,7 +136,7 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
          // For this reason we set the RECALL flag so that we can be called again manually when we know that there is
          // data pending.
 
-         RegisterFD((HOSTHANDLE)Self->Handle, RFD::RECALL|RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&server_incoming_from_client), Self);
+         RegisterFD(Self->Handle.hosthandle(), RFD::RECALL|RFD::READ|RFD::SOCKET, &server_incoming_from_client, Self);
       }
 
       return ERR::Okay;
@@ -173,13 +173,13 @@ static ERR receive_from_client(extClientSocket *Self, APTR Buffer, size_t Buffer
 //********************************************************************************************************************
 // Data has arrived from a client's socket handle.
 
-static void server_incoming_from_client(HOSTHANDLE Handle, extClientSocket *client)
+static void server_incoming_from_client_impl(HOSTHANDLE SocketFD, extClientSocket *client)
 {
    pf::Log log(__FUNCTION__);
    if (!client->Client) return;
    auto Server = (extNetSocket *)(client->Client->Owner);
 
-   if (client->Handle IS NOHANDLE) {
+   if (client->Handle.is_invalid()) {
       log.warning(ERR::InvalidState); // Socket closed but receiving data.
       return;
    }
@@ -245,7 +245,7 @@ static void server_incoming_from_client(HOSTHANDLE Handle, extClientSocket *clie
    Server->InUse++;
    client->ReadCalled = false;
 
-   log.traceBranch("Handle: %" PRId64 ", Socket: %d, Client: %d", (int64_t)Handle, Server->UID, client->UID);
+   log.traceBranch("Handle: %d, Socket: %d, Client: %d", SocketFD, Server->UID, client->UID);
 
    auto error = ERR::Okay;
    if (Server->Incoming.defined()) {
@@ -280,7 +280,7 @@ static void server_incoming_from_client(HOSTHANDLE Handle, extClientSocket *clie
 // no data is being written to the queue, the program will not be able to sleep until the client stops listening
 // to the write queue.
 
-static void clientsocket_outgoing(HOSTHANDLE Void, extClientSocket *ClientSocket)
+static void clientsocket_outgoing_impl(HOSTHANDLE SocketFD, extClientSocket *ClientSocket)
 {
    pf::Log log(__FUNCTION__);
    auto Server = (extNetSocket *)(ClientSocket->Client->Owner);
@@ -361,9 +361,9 @@ static void clientsocket_outgoing(HOSTHANDLE Void, extClientSocket *ClientSocket
       // we don't tax system resources.
 
       if (ClientSocket->WriteQueue.Buffer.empty()) {
-         log.trace("[NetSocket:%d] Write-queue listening on FD %d will now stop.", Server->UID, ClientSocket->Handle);
+         log.trace("[NetSocket:%d] Write-queue listening on FD %d will now stop.", Server->UID, ClientSocket->Handle.int_value());
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)ClientSocket->Handle, RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
+            RegisterFD(ClientSocket->Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
          #elif _WIN32
             win_socketstate(ClientSocket->Handle, std::nullopt, false);
          #endif
@@ -467,7 +467,7 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
          Self->SSLHandle = ssl_create_context(false, true); // No verification, server mode
          if (Self->SSLHandle) {
             ssl_set_server_certificate(server->SSLHandle, Self->SSLHandle);
-            ssl_set_socket(Self->SSLHandle, (void*)(size_t)Self->Handle); // Set socket handle for server-side SSL
+            ssl_set_socket(Self->SSLHandle, (void*)(size_t)Self->Handle.socket()); // Set socket handle for server-side SSL
             Self->State = NTC::HANDSHAKING;
          }
          else Self->State = NTC::DISCONNECTED;
@@ -518,7 +518,7 @@ static ERR CLIENTSOCKET_Init(extClientSocket *Self)
 #endif
 
 #ifdef __linux__
-   RegisterFD(Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&server_incoming_from_client), Self);
+   RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &server_incoming_from_client, Self);
 #elif _WIN32
    win_socket_reference(Self->Handle, Self);
 #endif
@@ -555,7 +555,7 @@ static ERR CLIENTSOCKET_Read(extClientSocket *Self, struct acRead *Args)
 {
    pf::Log log;
    if ((!Args) or (!Args->Buffer)) return log.error(ERR::NullArgs);
-   if (Self->Handle IS NOHANDLE) {
+   if (Self->Handle.is_invalid()) {
       // Lack of a handle means that disconnection has already been processed, so the client code
       // shouldn't be calling us (client probably needs to be plugged into the feedback mechanisms)
       return log.warning(ERR::Disconnected);
@@ -597,7 +597,7 @@ static ERR CLIENTSOCKET_Write(extClientSocket *Self, struct acWrite *Args)
 
    auto server = (extNetSocket *)(Self->Client->Owner);
 
-   if ((Self->Handle IS NOHANDLE) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
+   if ((Self->Handle.is_invalid()) or (Self->State != NTC::CONNECTED)) { // Queue the write prior to server connection
       log.trace("Saving %d bytes to queue.", Args->Length);
       Self->WriteQueue.write(Args->Buffer, std::min<size_t>(Args->Length, server->MsgLimit));
       return ERR::Okay;
@@ -620,7 +620,7 @@ static ERR CLIENTSOCKET_Write(extClientSocket *Self, struct acWrite *Args)
          log.trace("Error: '%s', queuing %d/%d bytes for transfer...", GetErrorMsg(error), Args->Length - len, Args->Length);
          Self->WriteQueue.write((int8_t *)Args->Buffer + len, std::min<size_t>(Args->Length - len, server->MsgLimit));
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&clientsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &clientsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif
@@ -691,7 +691,7 @@ static ERR CS_SET_State(extClientSocket *Self, NTC Value)
       if ((Self->State IS NTC::CONNECTED) and ((!Self->WriteQueue.Buffer.empty()))) {
          log.msg("Sending queued data to server on connection.");
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&clientsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &clientsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif

--- a/src/network/netsocket/netsocket_fields.cpp
+++ b/src/network/netsocket/netsocket_fields.cpp
@@ -207,11 +207,11 @@ static ERR SET_Outgoing(extNetSocket *Self, FUNCTION *Value)
    if (Self->Outgoing.isScript()) SubscribeAction(Self->Outgoing.Context, AC::Free, C_FUNCTION(notify_free_outgoing));
 
    if (Self->initialised()) {
-      if ((Self->Handle != NOHANDLE) and (Self->State IS NTC::CONNECTED)) {
+      if ((Self->Handle.is_valid()) and (Self->State IS NTC::CONNECTED)) {
          // Setting the Outgoing field after connectivity is established will put the socket into streamed write mode.
 
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif
@@ -247,7 +247,7 @@ Handle: Platform specific reference to the network socket handle.
 
 static ERR GET_Handle(extNetSocket *Self, APTR *Value)
 {
-   *Value = (APTR)(MAXINT)Self->Handle;
+   *Value = (APTR)(MAXINT)Self->Handle.socket();
    return ERR::Okay;
 }
 
@@ -256,7 +256,7 @@ static ERR SET_Handle(extNetSocket *Self, APTR Value)
    // The user can set Handle prior to initialisation in order to create a NetSocket object that is linked to a
    // socket created from outside the core platform code base.
 
-   Self->Handle = (SOCKET_HANDLE)(MAXINT)Value;
+   Self->Handle = SocketHandle(int((MAXINT)Value));
    Self->ExternalSocket = true;
    return ERR::Okay;
 }
@@ -453,7 +453,7 @@ static ERR SET_State(extNetSocket *Self, NTC Value)
       if ((Self->State IS NTC::CONNECTED) and ((!Self->WriteQueue.Buffer.empty()) or (Self->Outgoing.defined()))) {
          log.msg("Sending queued data to server on connection.");
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_outgoing), Self);
+            RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::SOCKET, &netsocket_outgoing, Self);
          #elif _WIN32
             win_socketstate(Self->Handle, std::nullopt, true);
          #endif

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -5,16 +5,14 @@ static void free_socket(extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
-   log.branch("Handle: %d", Self->Handle);
+   log.branch("Handle: %d", Self->Handle.int_value());
 
-   if (Self->Handle != NOHANDLE) {
+   if (Self->Handle.is_valid()) {
       log.trace("Deregistering socket.");
-#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
-      DeregisterFD((HOSTHANDLE)Self->Handle);
-#pragma GCC diagnostic warning "-Wint-to-pointer-cast"
+      DeregisterFD(Self->Handle.hosthandle());
 
       if (!Self->ExternalSocket) CLOSESOCKET_THREADED(Self->Handle);
-      Self->Handle = NOHANDLE;
+      Self->Handle = SocketHandle();
    }
 
    Self->WriteQueue.Buffer.clear();
@@ -212,13 +210,13 @@ void win32_netresponse(OBJECTPTR SocketObject, SOCKET_HANDLE Handle, int Message
 // Called when a server socket handle detects a new client wanting to connect to it.
 // Used by Win32 (Windows message loop) & Linux (FD hook)
 
-static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
+static void server_accept_client_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
    uint8_t ip[8];
-   SOCKET_HANDLE clientfd;
+   SocketHandle clientfd;
 
-   log.traceBranch("FD: %d", FD);
+   log.traceBranch("FD: %d", SocketFD);
 
    pf::SwitchContext context(Self);
 
@@ -251,8 +249,8 @@ static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
          // For dual-stack sockets, use sockaddr_storage to handle both IPv4 and IPv6
          struct sockaddr_storage addr_storage;
          socklen_t len = sizeof(addr_storage);
-         clientfd = accept(FD, (struct sockaddr *)&addr_storage, &len);
-         if (clientfd IS NOHANDLE) return;
+         clientfd = accept(SocketFD, (struct sockaddr *)&addr_storage, &len);
+         if (clientfd.is_invalid()) return;
 
          int nodelay = 1;
          setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
@@ -329,9 +327,9 @@ static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
 
       #ifdef __linux__
          socklen_t len = sizeof(addr);
-         clientfd = accept(FD, (struct sockaddr *)&addr, &len);
+         clientfd = accept(SocketFD, (struct sockaddr *)&addr, &len);
 
-         if (clientfd != NOHANDLE) {
+         if (clientfd.is_valid()) {
             int nodelay = 1;
             setsockopt(clientfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
          }
@@ -340,7 +338,7 @@ static void server_accept_client(SOCKET_HANDLE FD, extNetSocket *Self)
          clientfd = win_accept(Self, FD, (struct sockaddr *)&addr, &len);
       #endif
 
-      if (clientfd IS NOHANDLE) {
+      if (clientfd.is_invalid()) {
          log.warning("accept() failed to return an FD.");
          return;
       }
@@ -484,10 +482,9 @@ static void free_client(extNetSocket *Socket, objNetClient *Client)
 // See win32_netresponse() for the Windows version.
 
 #ifdef __linux__
-static void client_connect(SOCKET_HANDLE Void, APTR Data)
+static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
-   auto Self = (extNetSocket *)Data;
 
    pf::SwitchContext context(Self);
 
@@ -495,11 +492,11 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
 
    int result = EHOSTUNREACH; // Default error in case getsockopt() fails
    socklen_t optlen = sizeof(result);
-   getsockopt(Self->Handle, SOL_SOCKET, SO_ERROR, &result, &optlen);
+   getsockopt(SocketFD, SOL_SOCKET, SO_ERROR, &result, &optlen);
 
    // Remove the write callback
 
-   RegisterFD((HOSTHANDLE)Self->Handle, RFD::WRITE|RFD::REMOVE, &client_connect, nullptr);
+   RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::REMOVE, &netsocket_connect, nullptr);
 
    #ifndef DISABLE_SSL
    if ((Self->SSLHandle) and (!result)) {
@@ -511,7 +508,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
       if (Self->Error != ERR::Okay) return;
 
       if (Self->State IS NTC::HANDSHAKING) {
-         RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+         RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
       }
       return;
    }
@@ -523,7 +520,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
       if (Self->TimerHandle) { UpdateTimer(Self->TimerHandle, 0); Self->TimerHandle = 0; }
 
       Self->setState(NTC::CONNECTED);
-      RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(&netsocket_incoming), Self);
+      RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, &netsocket_incoming, Self);
       return;
    }
    else {
@@ -552,7 +549,7 @@ static void client_connect(SOCKET_HANDLE Void, APTR Data)
 //
 // This function is called from win32_netresponse() and is managed outside of the normal message queue.
 
-static void netsocket_incoming(SOCKET_HANDLE FD, extNetSocket *Self)
+static void netsocket_incoming_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
@@ -567,7 +564,7 @@ static void netsocket_incoming(SOCKET_HANDLE FD, extNetSocket *Self)
 
    if (Self->Terminating) { // Set by FreeWarning()
       log.trace("Socket terminating...", Self->UID);
-      if (Self->Handle != NOHANDLE) free_socket(Self);
+      if (Self->Handle.is_valid()) free_socket(Self);
       return;
    }
 
@@ -608,12 +605,12 @@ static void netsocket_incoming(SOCKET_HANDLE FD, extNetSocket *Self)
 #endif
 
    if (Self->IncomingRecursion) {
-      log.trace("[NetSocket:%d] Recursion detected on handle %" PRId64, Self->UID, (int64_t)FD);
+      log.trace("[NetSocket:%d] Recursion detected on handle %d", Self->UID, SocketFD);
       if (Self->IncomingRecursion < 2) Self->IncomingRecursion++; // Indicate that there is more data to be received
       return;
    }
 
-   log.traceBranch("[NetSocket:%d] Socket: %" PRId64, Self->UID, (int64_t)FD);
+   log.traceBranch("[NetSocket:%d] Socket: %d", Self->UID, SocketFD);
 
    Self->InUse++;
    Self->IncomingRecursion++;
@@ -654,8 +651,8 @@ restart:
    }
 
    if (error IS ERR::Terminate) {
-      log.traceBranch("Socket %d will be terminated.", FD);
-      if (Self->Handle != NOHANDLE) free_socket(Self);
+      log.traceBranch("Socket %d will be terminated.", SocketFD);
+      if (Self->Handle.is_valid()) free_socket(Self);
    }
    else if (Self->IncomingRecursion > 1) {
       // If netsocket_incoming() was called again during the callback, there is more
@@ -689,7 +686,7 @@ restart:
 //
 // Called from either the Windows messaging logic or a Linux FD subscription.
 
-static void netsocket_outgoing(SOCKET_HANDLE Void, extNetSocket *Self)
+static void netsocket_outgoing_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 {
    pf::Log log(__FUNCTION__);
 
@@ -760,9 +757,9 @@ static void netsocket_outgoing(SOCKET_HANDLE Void, extNetSocket *Self)
       // be assigned temporarily.
 
       if ((!Self->Outgoing.defined()) and (Self->WriteQueue.Buffer.empty())) {
-         log.trace("Write-queue listening on socket %d will now stop.", Self->UID, Self->Handle);
+         log.trace("Write-queue listening on socket %d will now stop.", Self->UID, Self->Handle.int_value());
          #ifdef __linux__
-            RegisterFD((HOSTHANDLE)Self->Handle, RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
+            RegisterFD(Self->Handle.hosthandle(), RFD::REMOVE|RFD::WRITE|RFD::SOCKET, nullptr, nullptr);
          #elif _WIN32
             if (auto error = win_socketstate(Self->Handle, std::nullopt, false); error != ERR::Okay) log.warning(error);
          #endif

--- a/src/network/netsocket/netsocket_functions.cpp
+++ b/src/network/netsocket/netsocket_functions.cpp
@@ -496,7 +496,7 @@ static void netsocket_connect_impl(HOSTHANDLE SocketFD, extNetSocket *Self)
 
    // Remove the write callback
 
-   RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::REMOVE, &netsocket_connect, nullptr);
+   RegisterFD(Self->Handle.hosthandle(), RFD::WRITE|RFD::REMOVE, &netsocket_connect_impl, nullptr);
 
    #ifndef DISABLE_SSL
    if ((Self->SSLHandle) and (!result)) {

--- a/src/network/network.cpp
+++ b/src/network/network.cpp
@@ -31,6 +31,8 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
  #include <sys/resource.h>
 #endif
 
+#include <string.h>
+
 #include <parasol/main.h>
 #include <parasol/modules/network.h>
 #include <parasol/strings.hpp>
@@ -58,6 +60,8 @@ sockets and HTTP, please refer to the @NetSocket and @HTTP classes.
 #include <cstring>
 #include <thread>
 #include <optional>
+
+//********************************************************************************************************************
 
 std::mutex glmThreads;
 std::unordered_set<std::shared_ptr<std::jthread>> glThreads;
@@ -89,13 +93,7 @@ enum class SHS : uint8_t {
 
 DEFINE_ENUM_FLAG_OPERATORS(SHS)
 
-#ifdef __linux__
-typedef int SOCKET_HANDLE;
-#elif _WIN32
-typedef uint32_t SOCKET_HANDLE; // NOTE: declared as uint32_t instead of SOCKET for now to avoid including winsock.h
-#else
-#error "No support for this platform"
-#endif
+//********************************************************************************************************************
 
 #ifdef _WIN32
    #define INADDR_NONE 0xffffffff
@@ -226,7 +224,33 @@ typedef uint32_t SOCKET_HANDLE; // NOTE: declared as uint32_t instead of SOCKET 
       close(Handle);
    }
 
+// For Linux, create a simple wrapper that behaves like an int but with methods
+class SocketHandle {
+private:
+   int socket_val;
+public:
+   SocketHandle() : socket_val(-1) {}
+   SocketHandle(int sock) : socket_val(sock) {}
+
+   operator int() const { return socket_val; }
+   operator bool() const { return socket_val != -1; }
+
+   int int_value() const { return socket_val; }
+   int hosthandle() const { return socket_val; }
+   int socket() const { return socket_val; }
+
+   bool is_valid() const { return socket_val != -1; }
+   bool is_invalid() const { return socket_val == -1; }
+
+   bool operator==(const SocketHandle& other) const { return socket_val == other.socket_val; }
+   bool operator!=(const SocketHandle& other) const { return socket_val != other.socket_val; }
+   bool operator==(int sock) const { return socket_val == sock; }
+   bool operator!=(int sock) const { return socket_val != sock; }
+
+   SocketHandle& operator=(int sock) { socket_val = sock; return *this; }
+};
 #elif _WIN32
+   #include "win32/winsockwrappers.h"
 
    #include <string.h>
 
@@ -240,14 +264,11 @@ typedef uint32_t SOCKET_HANDLE; // NOTE: declared as uint32_t instead of SOCKET 
       int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
       void freeaddrinfo(struct addrinfo *res);
    }
-
-#else
-   #error "No support for this platform"
 #endif
 
 class extClientSocket : public objClientSocket {
    public:
-   SOCKET_HANDLE Handle = NOHANDLE;
+   SocketHandle Handle;
    struct NetQueue WriteQueue; // Writes to the network socket are queued here in a buffer
    uint8_t OutgoingRecursion;  // Recursion manager
    uint8_t InUse;       // Recursion manager
@@ -265,9 +286,11 @@ class extClientSocket : public objClientSocket {
    #endif
 };
 
+//********************************************************************************************************************
+
 class extNetSocket : public objNetSocket {
    public:
-   SOCKET_HANDLE Handle = NOHANDLE;   // Handle of the socket
+   SocketHandle Handle;   // Handle of the socket
    FUNCTION Outgoing;
    FUNCTION Incoming;
    FUNCTION Feedback;
@@ -366,7 +389,7 @@ typedef ankerl::unordered_dense::map<std::string, DNSEntry, CaseInsensitiveHash,
 
 //********************************************************************************************************************
 
-static void CLOSESOCKET_THREADED(SOCKET_HANDLE Handle)
+static void CLOSESOCKET_THREADED(SocketHandle Handle)
 {
 #ifdef _WIN32
    win_deregister_socket(Handle);
@@ -390,7 +413,7 @@ static void CLOSESOCKET_THREADED(SOCKET_HANDLE Handle)
 
    std::lock_guard<std::mutex> lock(glmThreads);
    auto thread_ptr = std::make_shared<std::jthread>();
-   *thread_ptr = std::jthread([] (int Handle) { CLOSESOCKET(Handle); }, Handle);
+   *thread_ptr = std::jthread([] (SocketHandle Handle) { CLOSESOCKET(Handle); }, Handle);
    glThreads.insert(thread_ptr);
    // Don't detach, threads need to be joinable for proper cleanup
 }
@@ -464,7 +487,6 @@ static std::string glCertPath;
 
 //********************************************************************************************************************
 
-static void netsocket_incoming(SOCKET_HANDLE, extNetSocket *);
 static ERR resolve_name_receiver(APTR Custom, MSGID MsgID, int MsgType, APTR Message, int MsgSize);
 static ERR resolve_addr_receiver(APTR Custom, MSGID MsgID, int MsgType, APTR Message, int MsgSize);
 
@@ -946,7 +968,7 @@ static ERR send_data(T *Self, CPTR Buffer, size_t *Length)
                case SSL_ERROR_WANT_READ:
                   log.trace("Handshake requested by server.");
                   Self->HandshakeStatus = SHS::READ;
-                  RegisterFD((HOSTHANDLE)Self->Handle, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_read<extNetSocket>), Self);
+                  RegisterFD(Self->Handle.hosthandle(), RFD::READ|RFD::SOCKET, ssl_handshake_read_netsocket, Self);
                   return ERR::Okay;
 
                case SSL_ERROR_SYSCALL:

--- a/src/network/openssl.cpp
+++ b/src/network/openssl.cpp
@@ -9,8 +9,34 @@ static ERR loadPEMCertificate(const std::string &, std::optional<const std::stri
 //********************************************************************************************************************
 
 // Forward declarations for template functions
-template <class T> void ssl_handshake_write(HOSTHANDLE Socket, T *Self);
-template <class T> void ssl_handshake_read(HOSTHANDLE Socket, T *Self);
+template <class T> void ssl_handshake_write_impl(HOSTHANDLE SocketFD, T *Self);
+template <class T> void ssl_handshake_read_impl(HOSTHANDLE SocketFD, T *Self);
+
+// Non-template wrappers for RegisterFD callbacks
+static void ssl_handshake_write_netsocket(HOSTHANDLE SocketFD, APTR Data) {
+   ssl_handshake_write_impl(SocketFD, (extNetSocket *)Data);
+}
+
+static void ssl_handshake_read_netsocket(HOSTHANDLE SocketFD, APTR Data) {
+   ssl_handshake_read_impl(SocketFD, (extNetSocket *)Data);
+}
+
+static void ssl_handshake_write_clientsocket(HOSTHANDLE SocketFD, APTR Data) {
+   ssl_handshake_write_impl(SocketFD, (extClientSocket *)Data);
+}
+
+static void ssl_handshake_read_clientsocket(HOSTHANDLE SocketFD, APTR Data) {
+   ssl_handshake_read_impl(SocketFD, (extClientSocket *)Data);
+}
+
+// Template wrappers for direct calls with SocketHandle
+template <class T> void ssl_handshake_write(SocketHandle Socket, T *Self) {
+   ssl_handshake_write_impl(Socket.hosthandle(), Self);
+}
+
+template <class T> void ssl_handshake_read(SocketHandle Socket, T *Self) {
+   ssl_handshake_read_impl(Socket.hosthandle(), Self);
+}
 
 template <class T> void sslDisconnect(T *Self)
 {
@@ -521,21 +547,27 @@ static ERR sslConnect(extNetSocket *Self)
 // handshake and then ceases monitoring of the FD.  If SSL then needs to continue its handshake then it will tell us in
 // the RECEIVE() and SEND() functions.
 
-template <class T> void ssl_handshake_write(HOSTHANDLE Socket, T *Self)
+template <class T> void ssl_handshake_write_impl(HOSTHANDLE SocketFD, T *Self)
 {
    pf::Log log(__FUNCTION__);
+   SocketHandle Socket(SocketFD);
 
-   log.trace("Socket: %" PF64, (MAXINT)Socket);
+   log.trace("Socket: %" PF64, (MAXINT)SocketFD);
+
+   auto write_callback = std::is_same<T, extNetSocket>::value ?
+      ssl_handshake_write_netsocket : ssl_handshake_write_clientsocket;
+   auto read_callback = std::is_same<T, extNetSocket>::value ?
+      ssl_handshake_read_netsocket : ssl_handshake_read_clientsocket;
 
    if (auto result = SSL_do_handshake(Self->SSLHandle); result == 1) { // Handshake successful, connection established
-      RegisterFD((HOSTHANDLE)Socket, RFD::WRITE|RFD::REMOVE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_write<T>), Self);
+      RegisterFD(Socket.hosthandle(), RFD::WRITE|RFD::REMOVE|RFD::SOCKET, write_callback, Self);
       Self->HandshakeStatus = SHS::NIL;
    }
    else switch (SSL_get_error(Self->SSLHandle, result)) {
       case SSL_ERROR_WANT_READ:
-         RegisterFD((HOSTHANDLE)Socket, RFD::WRITE|RFD::REMOVE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_write<T>), Self);
+         RegisterFD(Socket.hosthandle(), RFD::WRITE|RFD::REMOVE|RFD::SOCKET, write_callback, Self);
          Self->HandshakeStatus = SHS::READ;
-         RegisterFD((HOSTHANDLE)Socket, RFD::READ|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_read<T>), Self);
+         RegisterFD(Socket.hosthandle(), RFD::READ|RFD::SOCKET, read_callback, Self);
          break;
 
       case SSL_ERROR_WANT_WRITE:
@@ -547,14 +579,20 @@ template <class T> void ssl_handshake_write(HOSTHANDLE Socket, T *Self)
    }
 }
 
-template <class T> void ssl_handshake_read(HOSTHANDLE Socket, T *Self)
+template <class T> void ssl_handshake_read_impl(HOSTHANDLE SocketFD, T *Self)
 {
    pf::Log log(__FUNCTION__);
+   SocketHandle Socket(SocketFD);
 
-   log.trace("Socket: %" PF64, (MAXINT)Socket);
+   log.trace("Socket: %" PF64, (MAXINT)SocketFD);
+
+   auto write_callback = std::is_same<T, extNetSocket>::value ?
+      ssl_handshake_write_netsocket : ssl_handshake_write_clientsocket;
+   auto read_callback = std::is_same<T, extNetSocket>::value ?
+      ssl_handshake_read_netsocket : ssl_handshake_read_clientsocket;
 
    if (auto result = SSL_do_handshake(Self->SSLHandle); result == 1) { // Handshake successful, connection established
-      RegisterFD((HOSTHANDLE)Socket, RFD::READ|RFD::REMOVE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_read<T>), Self);
+      RegisterFD(Socket.hosthandle(), RFD::READ|RFD::REMOVE|RFD::SOCKET, read_callback, Self);
       Self->HandshakeStatus = SHS::NIL;
    }
    else switch (SSL_get_error(Self->SSLHandle, result)) {
@@ -563,9 +601,9 @@ template <class T> void ssl_handshake_read(HOSTHANDLE Socket, T *Self)
          break;
 
       case SSL_ERROR_WANT_WRITE:
-         RegisterFD((HOSTHANDLE)Socket, RFD::READ|RFD::REMOVE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_read<T>), Self);
+         RegisterFD(Socket.hosthandle(), RFD::READ|RFD::REMOVE|RFD::SOCKET, read_callback, Self);
          Self->HandshakeStatus = SHS::WRITE;
-         RegisterFD((HOSTHANDLE)Socket, RFD::WRITE|RFD::SOCKET, reinterpret_cast<void (*)(HOSTHANDLE, APTR)>(ssl_handshake_write<T>), Self);
+         RegisterFD(Socket.hosthandle(), RFD::WRITE|RFD::SOCKET, write_callback, Self);
          break;
 
       default:

--- a/src/network/win32/win32_ssl.cpp
+++ b/src/network/win32/win32_ssl.cpp
@@ -142,7 +142,7 @@ template <class T> ERR sslConnect(T *Self)
    if (!Self->SSLHandle) return ERR::FieldNotSet;
 
    std::string hostname = Self->Address ? Self->Address : "";
-   auto result = ssl_connect(Self->SSLHandle, (void *)(size_t)Self->Handle, hostname);
+   auto result = ssl_connect(Self->SSLHandle, (void *)(size_t)Self->Handle.socket(), hostname);
 
    switch (result) {
       case SSL_OK:


### PR DESCRIPTION
This pull request refactors the network socket handling code to improve type safety and maintainability. The main change is the introduction and consistent use of a new `SocketHandle` class, replacing raw socket handle integers throughout the codebase. This affects both the client and server socket logic, including all interactions with the `RegisterFD` function and socket state checks. Additionally, function signatures and internal implementations have been updated to use more explicit types and wrapper functions, reducing the reliance on raw pointers and casts.