### PR TITLE
Implement xml:base base URI tracking

### DIFF
--- a/src/xml/uri_utils.h
+++ b/src/xml/uri_utils.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace xml::uri
+{
+   inline std::string normalise_uri_separators(std::string Value)
+   {
+      std::replace(Value.begin(), Value.end(), '\\', '/');
+      return Value;
+   }
+
+   inline bool is_absolute_uri(std::string_view Uri)
+   {
+      size_t index = 0u;
+      while (index < Uri.length()) {
+         char ch = Uri[index];
+         if (ch IS ':') return index > 0u;
+         if ((ch IS '/') or (ch IS '?') or (ch IS '#')) break;
+         ++index;
+      }
+      return false;
+   }
+
+   inline std::string strip_query_fragment(std::string_view Uri)
+   {
+      size_t pos = Uri.find_first_of("?#");
+      if (pos != std::string::npos) return std::string(Uri.substr(0u, pos));
+      return std::string(Uri);
+   }
+
+   inline std::string normalise_path_segments(std::string_view Path)
+   {
+      std::string path(Path);
+      std::vector<std::string> segments;
+      bool leading_slash = (!path.empty()) and (path.front() IS '/');
+      size_t start = leading_slash ? 1u : 0u;
+
+      while (start <= path.length()) {
+         size_t end = path.find('/', start);
+         std::string segment;
+         if (end IS std::string::npos) {
+            segment = path.substr(start);
+            start = path.length() + 1u;
+         }
+         else {
+            segment = path.substr(start, end - start);
+            start = end + 1u;
+         }
+
+         if (segment.empty() or (segment IS ".")) continue;
+         if (segment IS "..") {
+            if (!segments.empty()) segments.pop_back();
+            continue;
+         }
+
+         segments.push_back(segment);
+      }
+
+      std::string result;
+      if (leading_slash) result.push_back('/');
+
+      for (size_t index = 0u; index < segments.size(); ++index) {
+         if (index > 0u) result.push_back('/');
+         result.append(segments[index]);
+      }
+
+      if ((!path.empty()) and (path.back() IS '/') and (!result.empty()) and (result.back() != '/')) {
+         result.push_back('/');
+      }
+
+      return result;
+   }
+
+   inline std::string resolve_relative_uri(std::string_view Relative, std::string_view Base)
+   {
+      if (Relative.empty()) return std::string(Base);
+      if (is_absolute_uri(Relative)) return std::string(Relative);
+
+      std::string base_clean = strip_query_fragment(Base);
+      if (base_clean.empty()) return std::string();
+
+      std::string prefix;
+      std::string path = base_clean;
+
+      size_t scheme_pos = base_clean.find(':');
+      if (scheme_pos != std::string::npos) {
+         prefix = base_clean.substr(0u, scheme_pos + 1u);
+         path = base_clean.substr(scheme_pos + 1u);
+
+         if (path.rfind("//", 0u) IS 0u) {
+            size_t authority_end = path.find('/', 2u);
+            if (authority_end IS std::string::npos) {
+               std::string combined = prefix + path;
+               if ((!Relative.empty()) and (Relative.front() != '/')) combined.push_back('/');
+               combined.append(std::string(Relative));
+               return combined;
+            }
+
+            prefix.append(path.substr(0u, authority_end));
+            path = path.substr(authority_end);
+         }
+      }
+
+      std::string directory = path;
+      size_t last_slash = directory.rfind('/');
+      if (last_slash != std::string::npos) directory = directory.substr(0u, last_slash + 1u);
+      else directory.clear();
+
+      std::string relative_path = std::string(Relative);
+      if ((!relative_path.empty()) and (relative_path.front() IS '/')) {
+         std::string combined_path = normalise_path_segments(relative_path);
+         return prefix + combined_path;
+      }
+
+      std::string combined_path = directory;
+      combined_path.append(relative_path);
+      combined_path = normalise_path_segments(combined_path);
+
+      return prefix + combined_path;
+   }
+}
+

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -116,6 +116,7 @@ static ERR XML_Clear(extXML *Self)
    if (Self->Path) { FreeResource(Self->Path); Self->Path = nullptr; }
 
    Self->Tags.clear();
+   Self->BaseURIMap.clear();
    if (Self->DocType)  { FreeResource(Self->DocType); Self->DocType = nullptr; }
    if (Self->PublicID) { FreeResource(Self->PublicID); Self->PublicID = nullptr; }
    if (Self->SystemID) { FreeResource(Self->SystemID); Self->SystemID = nullptr; }

--- a/src/xml/xpath/xpath_functions.cpp
+++ b/src/xml/xpath/xpath_functions.cpp
@@ -21,6 +21,7 @@
 #include "xpath_functions.h"
 #include "../xml.h"
 #include "../schema/type_checker.h"
+#include "../uri_utils.h"
 
 #include <algorithm>
 #include <array>
@@ -276,113 +277,10 @@ static std::string simple_normalise_unicode(const std::string &Value, std::strin
    return Value;
 }
 
-static bool is_absolute_uri(std::string_view Uri)
-{
-   size_t index = 0u;
-   while (index < Uri.length()) {
-      char ch = Uri[index];
-      if (ch IS ':') return index > 0u;
-      if ((ch IS '/') or (ch IS '?') or (ch IS '#')) break;
-      ++index;
-   }
-   return false;
-}
-
-static std::string strip_query_fragment(std::string_view Uri)
-{
-   size_t pos = Uri.find_first_of("?#");
-   if (pos != std::string::npos) return std::string(Uri.substr(0u, pos));
-   return std::string(Uri);
-}
-
-static std::string normalise_path_segments(const std::string &Path)
-{
-   std::vector<std::string> segments;
-   bool leading_slash = (!Path.empty()) and (Path.front() IS '/');
-   size_t start = leading_slash ? 1u : 0u;
-
-   while (start <= Path.length()) {
-      size_t end = Path.find('/', start);
-      std::string segment;
-      if (end IS std::string::npos) {
-         segment = Path.substr(start);
-         start = Path.length() + 1u;
-      } else {
-         segment = Path.substr(start, end - start);
-         start = end + 1u;
-      }
-
-      if (segment.empty() or (segment IS ".")) continue;
-      if (segment IS "..") {
-         if (!segments.empty()) segments.pop_back();
-         continue;
-      }
-
-      segments.push_back(segment);
-   }
-
-   std::string result;
-   if (leading_slash) result.push_back('/');
-
-   for (size_t index = 0u; index < segments.size(); ++index) {
-      if (index > 0u) result.push_back('/');
-      result.append(segments[index]);
-   }
-
-   if ((!Path.empty()) and (Path.back() IS '/') and (!result.empty()) and (result.back() != '/')) {
-      result.push_back('/');
-   }
-
-   return result;
-}
-
-static std::string resolve_relative_uri(std::string_view Relative, std::string_view Base)
-{
-   if (Relative.empty()) return std::string(Base);
-   if (is_absolute_uri(Relative)) return std::string(Relative);
-
-   std::string base_clean = strip_query_fragment(Base);
-   if (base_clean.empty()) return std::string();
-
-   std::string prefix;
-   std::string path = base_clean;
-
-   size_t scheme_pos = base_clean.find(':');
-   if (scheme_pos != std::string::npos) {
-      prefix = base_clean.substr(0u, scheme_pos + 1u);
-      path = base_clean.substr(scheme_pos + 1u);
-
-      if (path.rfind("//", 0u) IS 0u) {
-         size_t authority_end = path.find('/', 2u);
-         if (authority_end IS std::string::npos) {
-            std::string combined = prefix + path;
-            if ((!Relative.empty()) and (Relative.front() != '/')) combined.push_back('/');
-            combined.append(std::string(Relative));
-            return combined;
-         }
-
-         prefix.append(path.substr(0u, authority_end));
-         path = path.substr(authority_end);
-      }
-   }
-
-   std::string directory = path;
-   size_t last_slash = directory.rfind('/');
-   if (last_slash != std::string::npos) directory = directory.substr(0u, last_slash + 1u);
-   else directory.clear();
-
-   std::string relative_path = std::string(Relative);
-   if ((!relative_path.empty()) and (relative_path.front() IS '/')) {
-      std::string combined_path = normalise_path_segments(relative_path);
-      return prefix + combined_path;
-   }
-
-   std::string combined_path = directory;
-   combined_path.append(relative_path);
-   combined_path = normalise_path_segments(combined_path);
-
-   return prefix + combined_path;
-}
+using xml::uri::is_absolute_uri;
+using xml::uri::strip_query_fragment;
+using xml::uri::normalise_path_segments;
+using xml::uri::resolve_relative_uri;
 
 struct DateTimeComponents
 {


### PR DESCRIPTION
## Summary
- track resolved base URIs during parsing and cache them per tag for later lookups
- share URI normalisation and resolution helpers across the XML parser and XPath support code
- teach the XPath accessor utilities to read cached base URIs before falling back to legacy xml:base scans

## Testing
- ctest --build-config FastBuild --test-dir build/agents -R xml_xpath2_accessor

------
https://chatgpt.com/codex/tasks/task_e_68e046cd2484832eb8f432f7c99129ab