### PR TITLE
Refactor XPath evaluator callback handling

### DIFF
--- a/src/xml/xpath/xpath_evaluator.h
+++ b/src/xml/xpath/xpath_evaluator.h
@@ -61,6 +61,7 @@ class XPathEvaluator {
       uint32_t CurrentPrefix, std::vector<AxisMatch> &Candidates, std::vector<AxisMatch> &ScratchBuffer);
    ERR process_step_matches(const std::vector<AxisMatch> &Matches, AxisType Axis, bool IsLastStep,
       bool &Matched, std::vector<AxisMatch> &NextContext, bool &ShouldTerminate);
+   ERR invoke_callback(XMLTag *Node, const XMLAttrib *Attribute, bool &Matched, bool &ShouldTerminate);
 
    PredicateResult dispatch_predicate_operation(std::string_view OperationName, const XPathNode *Expression,
       uint32_t CurrentPrefix);


### PR DESCRIPTION
## Summary
- add an invoke_callback helper that centralises XPath callback setup and execution logic
- reuse the helper for attribute, element, and node-set terminal matches to keep cursor and callback behaviour consistent

## Testing
- cmake --build build/agents --config FastBuild --target xml --parallel

------
https://chatgpt.com/codex/tasks/task_e_68e06ae340a0832e92a5a9bb2c1e95b9