### PR TITLE
Document XPath axis helpers

### DIFF
--- a/src/xml/xpath/xpath_axis.h
+++ b/src/xml/xpath/xpath_axis.h
@@ -1,9 +1,8 @@
-// XPath Axis Evaluation System
-//
-// This file contains:
-// - Axis type definitions (Phase 4 of AST_PLAN.md)
-// - Axis evaluation logic for traversing XML document structure
-// - Support for all XPath 1.0 axes
+// Defines the XPath axis evaluation subsystem responsible for translating abstract axis operations
+// into concrete traversals of Parasol's XMLTag tree.  The header publishes the AxisType enumeration,
+// the AxisEvaluator helper, and supporting data structures that keep namespace nodes, document order,
+// and ancestor caches consistent across evaluations.  The accompanying implementation applies these
+// declarations to realise the full set of XPath 1.0 navigation semantics.
 
 #pragma once
 


### PR DESCRIPTION
## Summary
- add module-level documentation to the XPath arena helper so its pooling role is clearer
- expand AxisEvaluator comments for axis lookup, sibling traversal, namespace pooling, and document ordering utilities

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e100b6b27c832ea9fefea097802d6d