### PR TITLE
Clamp pf::vector capacity growth at minimum threshold

### DIFF
--- a/include/parasol/vector.hpp
+++ b/include/parasol/vector.hpp
@@ -41,12 +41,18 @@ private:
    };
 
 public:
-   vector(size_type capacity = MIN_CAPACITY) :
-      capacity(capacity), length(0), elements((T*)(::operator new(sizeof(T) * capacity)))
-   { }
+   vector(size_type requested_capacity = MIN_CAPACITY) :
+      capacity(requested_capacity < MIN_CAPACITY ? MIN_CAPACITY : requested_capacity), length(0), elements(nullptr)
+   {
+      if (capacity < 1) {
+         capacity = 1;
+      }
+      elements = (T*)(::operator new(sizeof(T) * capacity));
+   }
 
    template<std::input_iterator I> vector(I begin, I end) : capacity(std::distance(begin, end)), length(0) {
       if (capacity < MIN_CAPACITY) capacity = MIN_CAPACITY;
+      if (capacity < 1) capacity = 1;
       elements = (T*)(::operator new(sizeof(T) * capacity));
       for (auto i = begin; i != end; ++i) {
          pushBackInternal(*i);
@@ -62,6 +68,7 @@ public:
 
    vector(vector const &copy) : capacity(copy.length), length(0) {
       if (capacity < MIN_CAPACITY) capacity = MIN_CAPACITY;
+      if (capacity < 1) capacity = 1;
       elements = (T*)(::operator new(sizeof(T) * capacity));
       std::uninitialized_copy(copy.elements, copy.elements + copy.length, elements);
       length = copy.length;
@@ -199,6 +206,12 @@ public:
 
       if (length + count > capacity) {
          size_type new_capacity = capacity;
+         if (new_capacity < MIN_CAPACITY) {
+            new_capacity = MIN_CAPACITY;
+         }
+         if (new_capacity < 1) {
+            new_capacity = 1;
+         }
          while (new_capacity < length + count) {
             new_capacity = new_capacity * 2;
          }
@@ -267,6 +280,12 @@ private:
    }
 
    inline void reserveCapacity(size_type newCapacity) noexcept {
+      if (newCapacity < MIN_CAPACITY) {
+         newCapacity = MIN_CAPACITY;
+      }
+      if (newCapacity < 1) {
+         newCapacity = 1;
+      }
       vector<T> tmpBuffer(newCapacity);
       simpleCopy<T>(tmpBuffer);
       tmpBuffer.swap(*this);

--- a/src/core/tests/pf_vector.cpp
+++ b/src/core/tests/pf_vector.cpp
@@ -128,6 +128,13 @@ void test_basic_accessors(TestContext &Context) {
    Context.expect_equal(numbers.size(), std::size_t(0), "Size returns to zero after pop_back");
 }
 
+void test_zero_capacity_growth(TestContext &Context) {
+   pf::vector<int> values(0);
+   values.push_back(1);
+   Context.expect_equal(values.size(), std::size_t(1), "push_back succeeds after zero-capacity construction");
+   Context.expect_equal(values.front(), 1, "push_back stores value in zero-capacity regression");
+}
+
 void test_range_and_initializer_construction(TestContext &Context) {
    std::array<int, 3> array_values{1, 2, 3};
    pf::vector<int> from_range(array_values.begin(), array_values.end());
@@ -456,6 +463,7 @@ void test_insertion_lifecycle_management(TestContext &Context) {
 int main() {
    TestContext test_context;
    test_basic_accessors(test_context);
+   test_zero_capacity_growth(test_context);
    test_range_and_initializer_construction(test_context);
    test_copy_move_semantics(test_context);
    test_iterator_coverage(test_context);


### PR DESCRIPTION
## Summary
- clamp pf::vector constructors and reserve logic to allocate at least the minimum capacity
- ensure range insert capacity growth starts from a non-zero value
- add a regression test that pushes into a zero-capacity pf::vector

## Testing
- cmake --build build/agents --config FastBuild

------
https://chatgpt.com/codex/tasks/task_e_68e4213d4b34832e90eea60895048ea8